### PR TITLE
Migration処理の修正

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Migration failed if some renderer is None `#49`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Migration failed if some renderer is None `#49`
 
 ### Security
 

--- a/Editor/Migration/Migration.cs
+++ b/Editor/Migration/Migration.cs
@@ -400,7 +400,7 @@ Do you want to migrate project now?",
 
             renderersSet.Clear();
 
-            var valuesSet = new HashSet<T>(values);
+            var valuesSet = new HashSet<T>(values.Where(value => value != null));
 
             foreach (var value in valuesSet)
                 renderersSet.GetElementOf(value).EnsureAdded();


### PR DESCRIPTION
Fixes #48 の対応
v0.1.4におけるMergeSkinnedMeshにNullが含まれていた場合、Migrationが失敗してしまうことの修正

