### PR TITLE
RemoveMeshInBoxが正常に動作しないことの修正

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- RemoveMeshInBox refers old v1 configuration `#60`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- RemoveMeshInBox refers old v1 configuration `#60`
 
 ### Security
 

--- a/Editor/Processors/SkinnedMeshes/RemoveMeshInBoxProcessor.cs
+++ b/Editor/Processors/SkinnedMeshes/RemoveMeshInBoxProcessor.cs
@@ -17,7 +17,7 @@ namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
             foreach (var vertex in target.Vertices)
             {
                 var actualPosition = vertex.ComputeActualPosition(target, Target.transform.worldToLocalMatrix);
-                vertex.AdditionalTemporal = Component.boxes.Any(x => x.ContainsVertex(actualPosition)) ? 0 : 1;
+                vertex.AdditionalTemporal = Component.boxList.GetAsList().Any(x => x.ContainsVertex(actualPosition)) ? 0 : 1;
             }
 
             foreach (var subMesh in target.SubMeshes)


### PR DESCRIPTION
#59 の対応

RemoveMeshInBoxProcessorにて判定に使っているのがv1のRemoveMeshInBox.boxesのままになっていたため、boxlistを見るように修正