### PR TITLE
fix: we can use Max Squish in PhysBone 1.0

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Max Squish is not shown if we're using PhysBone 1.0 `#127`
 
 ### Security
 

--- a/Editor/MergePhysBoneEditor.cs
+++ b/Editor/MergePhysBoneEditor.cs
@@ -227,8 +227,7 @@ namespace Anatawa12.AvatarOptimizer
                     if (CheckMinVersion(VRCPhysBoneBase.Version.Version_1_1))
                         PbCurveProp("Stretch Motion", "stretchMotion", "stretchMotionCurve", _stretchMotion);
                     PbCurveProp("Max Stretch", "maxStretch", "maxStretchCurve", _maxStretchProp);
-                    if (CheckMinVersion(VRCPhysBoneBase.Version.Version_1_1))
-                        PbCurveProp("Max Squish", "maxSquish", "maxSquishCurve", _maxSquish);
+                    PbCurveProp("Max Squish", "maxSquish", "maxSquishCurve", _maxSquish);
                 }
 
                 // == Grab & Pose ==


### PR DESCRIPTION
https://feedback.vrchat.com/open-beta/p/sdk-320-beta1-max-squish-is-shown-in-the-physbone-10
> As some others have indicated, Squish does work in version 1.0. The patch notes also say this in some places... and contradict it in others. Whoops. Sorry for the lack of clarity there!