### PR TITLE
fix: migration should check for read only package

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Migration fails with scenes/prefabs in read-only packages `#136`
+  - Now, migration process doesn't see any scenes/prefabs in read-only packages.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Migration fails with scenes/prefabs in read-only packages `#136`
+  - Now, migration process doesn't see any scenes/prefabs in read-only packages.
 
 ### Security
 

--- a/Editor/Migration/Migration.cs
+++ b/Editor/Migration/Migration.cs
@@ -104,7 +104,7 @@ Do you want to migrate project now?",
             try
             {
                 PreMigration();
-                var scenePaths = AssetDatabase.FindAssets("t:scene", new []{"Assets/"}).Select(AssetDatabase.GUIDToAssetPath).ToList();
+                var scenePaths = AssetDatabase.FindAssets("t:scene").Select(AssetDatabase.GUIDToAssetPath).ToList();
 
                 MigrateAllScenes(scenePaths, (name, i) => EditorUtility.DisplayProgressBar(
                     "Migrating Scenes",
@@ -130,7 +130,7 @@ Do you want to migrate project now?",
             {
                 PreMigration();
                 var prefabs = GetPrefabs();
-                var scenePaths = AssetDatabase.FindAssets("t:scene", new []{"Assets/"}).Select(AssetDatabase.GUIDToAssetPath).ToList();
+                var scenePaths = AssetDatabase.FindAssets("t:scene").Select(AssetDatabase.GUIDToAssetPath).ToList();
                 float totalCount = prefabs.Count + scenePaths.Count;
 
                 MigratePrefabs(prefabs, (name, i) => EditorUtility.DisplayProgressBar(
@@ -167,7 +167,7 @@ Do you want to migrate project now?",
             try
             {
                 var prefabs = GetPrefabs();
-                var scenePaths = AssetDatabase.FindAssets("t:scene", new []{"Assets/"}).Select(AssetDatabase.GUIDToAssetPath).ToList();
+                var scenePaths = AssetDatabase.FindAssets("t:scene").Select(AssetDatabase.GUIDToAssetPath).ToList();
                 float totalCount = prefabs.Count + scenePaths.Count;
 
                 MigratePrefabs(prefabs, (name, i) => EditorUtility.DisplayProgressBar(
@@ -654,7 +654,7 @@ Do you want to migrate project now?",
                 type != PrefabAssetType.MissingAsset && type != PrefabAssetType.Model &&
                 type != PrefabAssetType.NotAPrefab;
 
-            var allPrefabRoots = AssetDatabase.FindAssets("t:prefab", new []{"Assets/"})
+            var allPrefabRoots = AssetDatabase.FindAssets("t:prefab")
                 .Select(AssetDatabase.GUIDToAssetPath)
                 .Select(AssetDatabase.LoadAssetAtPath<GameObject>)
                 .Where(x => x)

--- a/Editor/Migration/Migration.cs
+++ b/Editor/Migration/Migration.cs
@@ -104,7 +104,7 @@ Do you want to migrate project now?",
             try
             {
                 PreMigration();
-                var scenePaths = AssetDatabase.FindAssets("t:scene").Select(AssetDatabase.GUIDToAssetPath).ToList();
+                var scenePaths = AssetDatabase.FindAssets("t:scene", new []{"Assets/"}).Select(AssetDatabase.GUIDToAssetPath).ToList();
 
                 MigrateAllScenes(scenePaths, (name, i) => EditorUtility.DisplayProgressBar(
                     "Migrating Scenes",
@@ -130,7 +130,7 @@ Do you want to migrate project now?",
             {
                 PreMigration();
                 var prefabs = GetPrefabs();
-                var scenePaths = AssetDatabase.FindAssets("t:scene").Select(AssetDatabase.GUIDToAssetPath).ToList();
+                var scenePaths = AssetDatabase.FindAssets("t:scene", new []{"Assets/"}).Select(AssetDatabase.GUIDToAssetPath).ToList();
                 float totalCount = prefabs.Count + scenePaths.Count;
 
                 MigratePrefabs(prefabs, (name, i) => EditorUtility.DisplayProgressBar(
@@ -167,7 +167,7 @@ Do you want to migrate project now?",
             try
             {
                 var prefabs = GetPrefabs();
-                var scenePaths = AssetDatabase.FindAssets("t:scene").Select(AssetDatabase.GUIDToAssetPath).ToList();
+                var scenePaths = AssetDatabase.FindAssets("t:scene", new []{"Assets/"}).Select(AssetDatabase.GUIDToAssetPath).ToList();
                 float totalCount = prefabs.Count + scenePaths.Count;
 
                 MigratePrefabs(prefabs, (name, i) => EditorUtility.DisplayProgressBar(
@@ -654,7 +654,7 @@ Do you want to migrate project now?",
                 type != PrefabAssetType.MissingAsset && type != PrefabAssetType.Model &&
                 type != PrefabAssetType.NotAPrefab;
 
-            var allPrefabRoots = AssetDatabase.FindAssets("t:prefab")
+            var allPrefabRoots = AssetDatabase.FindAssets("t:prefab", new []{"Assets/"})
                 .Select(AssetDatabase.GUIDToAssetPath)
                 .Select(AssetDatabase.LoadAssetAtPath<GameObject>)
                 .Where(x => x)


### PR DESCRIPTION
Fixes #135
`AssetDatabase#FindAssets` に `Assets/` フォルダのみのフィルタを掛けることで修正