### PR TITLE
Apply modified properties before draw custom editor

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Dropping PhysBone to MergePhysBone is not working `#221`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Dropping PhysBone to MergePhysBone is not working `#221`
 
 ### Security
 

--- a/Editor/MergePhysBoneEditor.cs
+++ b/Editor/MergePhysBoneEditor.cs
@@ -32,6 +32,8 @@ namespace Anatawa12.AvatarOptimizer
 
             EditorGUILayout.PropertyField(_componentsSetProp);
 
+            // on DragPerform, in DoProcess, new HelpBox invocation throws ExitGUIException
+            // so I ApplyModifiedProperties here.
             serializedObject.ApplyModifiedProperties();
 
             // draw custom editor

--- a/Editor/MergePhysBoneEditor.cs
+++ b/Editor/MergePhysBoneEditor.cs
@@ -32,6 +32,8 @@ namespace Anatawa12.AvatarOptimizer
 
             EditorGUILayout.PropertyField(_componentsSetProp);
 
+            serializedObject.ApplyModifiedProperties();
+
             // draw custom editor
             _renderer.DoProcess();
 


### PR DESCRIPTION
Fix #220 

`MergePhysBoneEditorModificationUtils.DoProcess()` 内でserializedObjectからプロパティを取得する前にプロパティの保存をしていないようです。
そのため、マージしたいPhysBoneをD&Dしてきても何も起きてないように見える現象が起きます。

描画前にApplyしてしまえば問題なさそうでしたので、draw custom editorの直前でApplyすることで修正しました。
もし他の手段で修正中などであればCloseしていただいて問題ないです。