### PR TITLE
fix tangentless mesh

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Breaks mesh without tangent `#271`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Breaks mesh without tangent `#271`
 
 ### Security
 

--- a/Editor/Processors/SkinnedMeshes/MergeSkinnedMeshProcessor.cs
+++ b/Editor/Processors/SkinnedMeshes/MergeSkinnedMeshProcessor.cs
@@ -94,6 +94,7 @@ namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
                 target.Bones.AddRange(meshInfo.Bones);
 
                 target.HasColor |= meshInfo.HasColor;
+                target.HasTangent |= meshInfo.HasTangent;
 
                 target.AssertInvariantContract($"processing meshInfo {Target.gameObject.name}");
             }

--- a/Editor/Processors/SkinnedMeshes/MeshInfo2.cs
+++ b/Editor/Processors/SkinnedMeshes/MeshInfo2.cs
@@ -407,7 +407,7 @@ namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
     {
         public Vector3 Position { get; set; }
         public Vector3 Normal { get; set; }
-        public Vector4 Tangent { get; set; }
+        public Vector4 Tangent { get; set; } = new Vector4(1, 0, 0, 1);
         public Vector4 TexCoord0 { get; set; }
         public Vector4 TexCoord1 { get; set; }
         public Vector4 TexCoord2 { get; set; }


### PR DESCRIPTION
I noticed when using any of the mesh modifying tools with Mamehinata, the outlines would disappear. I tracked it down to a problem with meshes that are imported with "Tangents: None". `MeshInfo2` assumed that all meshes have tangents and would assign tangents to the new mesh.

メッシュを変更する道具はまめひなたちゃんに使うと輪郭を消するのを気づきました。FBXを入る時に「Tangents: None」を使うの問題が見つけました。`MeshInfo2`はtangentなしメッシュがありませんと思い込みて新しいメッシュにtangentを入りました。

The Unity documentation says that normals are also optional. Unityの文献集はnormalがないメッシュもあると言います。

Mamehinata's FBX import settings:

![image](https://github.com/anatawa12/AvatarOptimizer/assets/93416656/a12b7cb1-0079-499f-9928-fcfcf4e6a1ca)

Demo scene that demonstrates the issue without Mamehinata (requires liltoon and AvatarOptimizer):

[demo.zip](https://github.com/anatawa12/AvatarOptimizer/files/12139605/demo.zip)
