### PR TITLE
fix: ClearEndpointPosition only applies to the first PhysBone on the GameObject

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- ClearEndpointPosition is not applied for non-first PhysBones on the GameObject `#357`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- ClearEndpointPosition is not applied for non-first PhysBones on the GameObject `#357`
 
 ### Security
 

--- a/Editor/Processors/ClearEndpointPositionProcessor.cs
+++ b/Editor/Processors/ClearEndpointPositionProcessor.cs
@@ -9,8 +9,8 @@ namespace Anatawa12.AvatarOptimizer.Processors
     {
         public void Process(OptimizerSession session)
         {
-            foreach (var component in session.GetComponents<ClearEndpointPosition>())
-                BuildReport.ReportingObject(component, () => Process(component.GetComponent<VRCPhysBoneBase>()));
+            BuildReport.ReportingObjects(session.GetComponents<ClearEndpointPosition>(),
+                component => BuildReport.ReportingObjects(component.GetComponents<VRCPhysBoneBase>(), Process));
         }
         
         public static void Process(VRCPhysBoneBase pb)


### PR DESCRIPTION
Closes #356 