### PR TITLE
fix: MergeBone with uneven scale is supported if all children are merged

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- MergeBone with uneven scale is supported if all children are merged `#426`
 
 ### Security
 

--- a/Editor/Processors/MergeBoneProcessor.cs
+++ b/Editor/Processors/MergeBoneProcessor.cs
@@ -22,15 +22,29 @@ namespace Anatawa12.AvatarOptimizer.Processors
                     .Any())
                     errors[0] = ErrorLog.Warning("MergeBone:validation:thereAreComponent");
 
-                var localScale = mergeBone.transform.localScale;
-                if (!CheckScale(localScale.x / localScale.y) || !CheckScale(localScale.x / localScale.z) ||
-                    !CheckScale(localScale.y / localScale.z))
-                    errors[1] = ErrorLog.Warning("MergeBone:validation:unevenScaling");
+                if (AnyNotMergedBone(mergeBone.transform))
+                {
+                    // if the bone has non-merged bones, uneven scaling is not supported.
+                    var localScale = mergeBone.transform.localScale;
+                    if (!CheckScale(localScale.x / localScale.y) || !CheckScale(localScale.x / localScale.z) ||
+                        !CheckScale(localScale.y / localScale.z))
+                        errors[1] = ErrorLog.Warning("MergeBone:validation:unevenScaling");
+                }
 
                 return errors;
             });
 
             bool CheckScale(float scale) => 0.999 < scale && scale < 1.001;
+
+            bool AnyNotMergedBone(Transform bone)
+            {
+                if (bone.CompareTag("EditorOnly")) return false;
+                if (!bone.GetComponent<MergeBone>()) return true;
+                foreach (var transform in bone.DirectChildrenEnumerable())
+                    if (AnyNotMergedBone(transform))
+                        return true;
+                return false;
+            }
         }
 
         public void Process(OptimizerSession session)

--- a/Localization/en.po
+++ b/Localization/en.po
@@ -92,7 +92,7 @@ msgid "MergeBone:validation:thereAreComponent"
 msgstr "There are some components other than Transform. This is not supported."
 
 msgid "MergeBone:validation:unevenScaling"
-msgstr "Merging bones with uneven scale is not supported."
+msgstr "Merging bones with uneven scale is not supported if there are descendant bone which is not merged."
 
 # endregion
 

--- a/Localization/ja.po
+++ b/Localization/ja.po
@@ -95,7 +95,7 @@ msgid "MergeBone:validation:thereAreComponent"
 msgstr "Transform以外のコンポーネントがあります。これはサポートされていません。"
 
 msgid "MergeBone:validation:unevenScaling"
-msgstr "子孫にマージされていないボーンがある場合、Scaleが均一でないボーンを統合することはサポートされていません。"
+msgstr "統合しないボーンが子孫にある場合、Scaleが均一でないボーンを統合することはサポートされていません。"
 
 # endregion
 

--- a/Localization/ja.po
+++ b/Localization/ja.po
@@ -95,7 +95,7 @@ msgid "MergeBone:validation:thereAreComponent"
 msgstr "Transform以外のコンポーネントがあります。これはサポートされていません。"
 
 msgid "MergeBone:validation:unevenScaling"
-msgstr "Scaleが均一でないボーンを統合することはサポートされていません。"
+msgstr "子孫にマージされていないボーンがある場合、Scaleが均一でないボーンを統合することはサポートされていません。"
 
 # endregion
 


### PR DESCRIPTION
Fixes #425