### PR TITLE
ContactBase is accidentally erased by Remove unsed Objects Automatically.

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- GC Objects will remove VRC Contact Components `#438`
 
 ### Security
 

--- a/Editor/Processors/TraceAndOptimize/ComponentDependencyCollector.cs
+++ b/Editor/Processors/TraceAndOptimize/ComponentDependencyCollector.cs
@@ -506,6 +506,7 @@ namespace Anatawa12.AvatarOptimizer.Processors.TraceAndOptimizes
 
             AddParser<ContactBase>((collector, deps, component) =>
             {
+                deps.EntrypointComponent = true;
                 deps.AddActiveDependency(component.rootTransform);
             });
             AddParserWithExtends<ContactBase, ContactReceiver>();


### PR DESCRIPTION
Remove unsed Objects Automaticallyでコンタクトが使用されている物にも関わらず、自動で削除されてしまっていたためこのPullRequestのドラフトを書きました

そのコンタクトが、アニメーションで常にオフ、または操作されていないためオフでない場合
ContactSenderは消すべきではなく、ほかのアバターに影響するため専用のような使い方がある、
ContactReceiverは、アニメーションのプロパティなどで、影響するか否かを見つつ消すべきで、アニメーションコントローラーが、そのパラメーターを持っていて、それを使用しているかなどで判断すればよいと思います。

今の状態でパラメーターのパーサーがあるのか私にはわからないので、それの回避策として"EntryPointComponent"を有効にすることで回避していますが、
パラメーターが使用されているかどうかのパーサーがある、または書く意思があるならこの回避策は使うべきではないので、PullRequestはクローズしてください。