### PR TITLE
chore: remove unused bone references just after reading mesh

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Remove unused bone references [`#498`](https://github.com/anatawa12/AvatarOptimizer/pull/498)
 
 ### Security
 

--- a/Editor/Processors/SkinnedMeshes/MeshInfo2.cs
+++ b/Editor/Processors/SkinnedMeshes/MeshInfo2.cs
@@ -65,7 +65,7 @@ namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
                 var bones = renderer.bones;
                 for (var i = 0; i < bones.Length && i < Bones.Count; i++) Bones[i].Transform = bones[i];
 
-                Optimize();
+                RemoveUnusedBones();
 
                 AssertInvariantContract("SkinnedMeshRenderer");
             });
@@ -268,6 +268,11 @@ namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
         }
 
         public void Optimize()
+        {
+            RemoveUnusedBones();
+        }
+
+        private void RemoveUnusedBones()
         {
             // GC Bones
             var usedBones = new HashSet<Bone>();

--- a/Editor/Processors/SkinnedMeshes/MeshInfo2.cs
+++ b/Editor/Processors/SkinnedMeshes/MeshInfo2.cs
@@ -65,6 +65,8 @@ namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
                 var bones = renderer.bones;
                 for (var i = 0; i < bones.Length && i < Bones.Count; i++) Bones[i].Transform = bones[i];
 
+                Optimize();
+
                 AssertInvariantContract("SkinnedMeshRenderer");
             });
         }


### PR DESCRIPTION
Edit by Anatawa12: Fixes #475

----

あるボーン A に PhysBone 等がアタッチされている場合、A にウェイトが乗っているメッシュがすべて削除されていても、関係ないはずの他のメッシュが残っていれば、TraceAndOptimize で A が削除されないようでした。(#475 でしょうか？)

例として
```
- Avatar
  - Armature
    - けもみみボーン (PhysBone 付き)
    - しっぽボーン (PhysBone 付き)
  - けもみみメッシュ
  - しっぽメッシュ
```
という構成のとき、`しっぽメッシュ` を削除したり常時非アクティブにすると、`しっぽボーン (PhysBone 付き)` は消えてもいいはずだけど残る、という内容です。

影響しそうなところは読んだつもりですが変なことをしていたらすみません。