### PR TITLE
docs: VPAIの記述をなくしてunitypackageインストールの説明をシンプルにする

### DIFF
--- a/.docs/content/_index.ja.md
+++ b/.docs/content/_index.ja.md
@@ -22,9 +22,9 @@ Avatar Optimizerは[VPM][vpm]レポジトリを使用して公開されている
 1. [このリンク][VCC-add-repo-link]をクリックしてanatawa12のレポジトリを追加する。
 2. VCCでAvatar Optimizerを追加する。
 
-### VPAIによるインストーラUnityPackageを使用する {#installation-vpai}
+### UnityPackageを使用する {#installation-vpai}
 
-[VPAI]により、unitypackageをインポートするだけでこのツールをインストールできます。
+unitypackageをインポートするだけでもこのツールをインストールできます。（VCCから追加する方法と全く同じようになります）
 
 1. [ここ][installer unitypackage 1.x.x]からインストーラunitypackageをダウンロードする。
 2. unitypackageをプロジェクトにインポートする。
@@ -37,6 +37,8 @@ Avatar Optimizerは[VPM][vpm]レポジトリを使用して公開されている
 - [0.3.x][installer unitypackage 0.3.x]
 - [0.4.x][installer unitypackage 0.4.x]
 - [0.x.x including beta releases][installer unitypackage x.x beta]
+
+このunitypackageによるVCCインストール機能は[VPAI]により実現されています。
 
 </details>
 

--- a/.docs/content/_index.md
+++ b/.docs/content/_index.md
@@ -22,9 +22,9 @@ Avatar Optimizer is published with [VPM][vpm] repository so you can install this
 1. Click [this link][VCC-add-repo-link] to add anatawa12's repository.
 2. Add Avatar Optimizer from VCC.
 
-### Using Installer UnityPackage with VPAI {#installation-vpai}
+### Using UnityPackage {#installation-vpai}
 
-With [VPAI] You can install this tool with just importing one unitypackage.
+You can install this tool with just importing one unitypackage.
 
 1. download installer unitypackage [here][installer unitypackage 1.x.x].
 2. Import the unitypackage into your project.
@@ -39,6 +39,8 @@ With [VPAI] You can install this tool with just importing one unitypackage.
 - [x.x.x including beta releases][installer unitypackage x.x beta]
 
 </details>
+
+This installation method is provided in thanks to [VPAI].
 
 ### Using vrc-get {#installation-vrc-get}
 


### PR DESCRIPTION
Fixes #524 

発端あたり
https://twitter.com/narazaka/status/1709862000808137137

なんかこんな感じのイメージ

- unitypackageでインストールする人はそもそも色々説明されると混乱する方だと思うので余計な説明は無い方が良いと思うため
- 雑にjaだけやった