### PR TITLE
Add Unity version defines

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Improve support of newer Unity versions `#608`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog].
 - Update notice may show incorrect version `#602`
 - `Preview` button is not disabled even if mesh is none `#605`
 - BindPose Optimization may break mesh with scale 0 bone `#612`
+- Improve support of newer Unity versions `#608`
 
 ### Security
 

--- a/Editor/APIBackend/ComponentInfos.cs
+++ b/Editor/APIBackend/ComponentInfos.cs
@@ -174,7 +174,11 @@ namespace Anatawa12.AvatarOptimizer.APIBackend
                 switch (component.collision.type)
                 {
                     case ParticleSystemCollisionType.Planes:
+#if UNITY_2020_2_OR_NEWER
+                        for (var i = 0; i < component.collision.planeCount; i++)
+#else
                         for (var i = 0; i < component.collision.maxPlaneCount; i++)
+#endif
                             collector.AddDependency(component.collision.GetPlane(i));
                         break;
                     case ParticleSystemCollisionType.World:
@@ -185,7 +189,11 @@ namespace Anatawa12.AvatarOptimizer.APIBackend
 
             if (component.trigger.enabled)
             {
+#if UNITY_2020_2_OR_NEWER
+                for (var i = 0; i < component.trigger.colliderCount; i++)
+#else
                 for (var i = 0; i < component.trigger.maxColliderCount; i++)
+#endif
                     collector.AddDependency(component.trigger.GetCollider(i));
             }
 

--- a/Editor/Processors/TraceAndOptimize/FindUnusedObjectsProcessor.cs
+++ b/Editor/Processors/TraceAndOptimize/FindUnusedObjectsProcessor.cs
@@ -112,13 +112,17 @@ namespace Anatawa12.AvatarOptimizer.Processors.TraceAndOptimizes
                 case OcclusionArea _:
                 case OcclusionPortal _:
                 case ParticleSystem _:
+#if !UNITY_2021_3_OR_NEWER
                 case ParticleSystemForceField _:
+#endif
                 case Rigidbody _:
                 case Rigidbody2D _:
                 case TextMesh _:
                 case Tree _:
                 case WindZone _:
+#if !UNITY_2020_2_OR_NEWER
                 case UnityEngine.XR.WSA.WorldAnchor _:
+#endif
                     activeness = true;
                     break;
                 case Component _:


### PR DESCRIPTION
Part of #607

- [ParticleSystemForceField](https://docs.unity3d.com/ja/2021.2/ScriptReference/ParticleSystemForceField.html) is `Behaviour` on Unity 2021.3 and higher instead of `Component` and is matched in earlier case
- [UnityEngine.XR.WSA.WorldAnchor](https://docs.unity3d.com/ja/2020.1/ScriptReference/XR.WSA.WorldAnchor.html) is removed on Unity 2020.2 and higher
- [ParticleSystem.CollisionModule.maxPlaneCount](https://docs.unity3d.com/ja/2020.1/ScriptReference/ParticleSystem.CollisionModule-maxPlaneCount.html) is obsolete on Unity 2020.2 and higher