### PR TITLE
Add VRCSDK version defines to asmdefs and code generators

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Improve support of projects without VRCSDK `#609`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog].
 - Update notice may show incorrect version `#602`
 - `Preview` button is not disabled even if mesh is none `#605`
 - BindPose Optimization may break mesh with scale 0 bone `#612`
+- Improve support of projects without VRCSDK `#609`
 
 ### Security
 

--- a/Editor/com.anatawa12.avatar-optimizer.editor.asmdef
+++ b/Editor/com.anatawa12.avatar-optimizer.editor.asmdef
@@ -38,6 +38,11 @@
             "name": "nadena.dev.modular-avatar",
             "expression": "(,1.8-a)",
             "define": "LEGACY_MODULAR_AVATAR"
+        },
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "",
+            "define": "AAO_VRCSDK3_AVATARS"
         }
     ],
     "noEngineReferences": false

--- a/Internal/ErrorReporter/Editor/com.anatawa12.avatar-optimizer.internal.error-reporter.editor.asmdef
+++ b/Internal/ErrorReporter/Editor/com.anatawa12.avatar-optimizer.internal.error-reporter.editor.asmdef
@@ -20,6 +20,12 @@
     ],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "",
+            "define": "AAO_VRCSDK3_AVATARS"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Internal/PrefabSafeSet/Runtime/com.anatawa12.avatar-optimizer.internal.prefab-safe-set.asmdef
+++ b/Internal/PrefabSafeSet/Runtime/com.anatawa12.avatar-optimizer.internal.prefab-safe-set.asmdef
@@ -12,6 +12,12 @@
     ],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "",
+            "define": "AAO_VRCSDK3_AVATARS"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Internal/PrefabSafeSet/Runtime/generate.ts
+++ b/Internal/PrefabSafeSet/Runtime/generate.ts
@@ -1,4 +1,11 @@
 
+const AAO_VRCSDK3_AVATARS = "AAO_VRCSDK3_AVATARS"; 
+function conditional(flag: string, inner: () => void) {
+    console.log(`#if ${flag}`)
+    inner();
+    console.log(`#endif`)
+}
+
 function generate(type: string) {
     console.log(`    [Serializable]`)
     console.log(`    public class ${type}Set : PrefabSafeSet<${type}, ${type}Set.Layer>`)
@@ -18,7 +25,9 @@ console.log(`using System.Collections.Generic;`)
 console.log(`using System.Reflection;`)
 console.log(`using JetBrains.Annotations;`)
 console.log(`using UnityEngine;`)
-console.log(`using VRC.Dynamics;`)
+conditional(AAO_VRCSDK3_AVATARS, () => {
+    console.log(`using VRC.Dynamics;`)
+});
 console.log(`using Object = UnityEngine.Object;`)
 console.log(``)
 console.log(`namespace Anatawa12.AvatarOptimizer.PrefabSafeSet`)
@@ -27,6 +36,8 @@ generate("SkinnedMeshRenderer")
 generate("MeshRenderer")
 generate("Material")
 generate("String")
-generate("VRCPhysBoneBase")
+conditional(AAO_VRCSDK3_AVATARS, () => {
+    generate("VRCPhysBoneBase")
+});
 generate("Transform")
 console.log(`}`)

--- a/Internal/PrefabSafeSet/Runtime/generated.cs
+++ b/Internal/PrefabSafeSet/Runtime/generated.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 using System.Reflection;
 using JetBrains.Annotations;
 using UnityEngine;
+#if AAO_VRCSDK3_AVATARS
 using VRC.Dynamics;
+#endif
 using Object = UnityEngine.Object;
 
 namespace Anatawa12.AvatarOptimizer.PrefabSafeSet
@@ -46,6 +48,7 @@ namespace Anatawa12.AvatarOptimizer.PrefabSafeSet
         [Serializable]
         public class Layer : PrefabLayer<String>{}
     }
+#if AAO_VRCSDK3_AVATARS
     [Serializable]
     public class VRCPhysBoneBaseSet : PrefabSafeSet<VRCPhysBoneBase, VRCPhysBoneBaseSet.Layer>
     {
@@ -55,6 +58,7 @@ namespace Anatawa12.AvatarOptimizer.PrefabSafeSet
         [Serializable]
         public class Layer : PrefabLayer<VRCPhysBoneBase>{}
     }
+#endif
     [Serializable]
     public class TransformSet : PrefabSafeSet<Transform, TransformSet.Layer>
     {

--- a/Runtime/com.anatawa12.avatar-optimizer.runtime.asmdef
+++ b/Runtime/com.anatawa12.avatar-optimizer.runtime.asmdef
@@ -18,6 +18,12 @@
     ],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "",
+            "define": "AAO_VRCSDK3_AVATARS"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Test~/com.anatawa12.avatar-optimizer.test.asmdef
+++ b/Test~/com.anatawa12.avatar-optimizer.test.asmdef
@@ -26,6 +26,12 @@
     ],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "",
+            "define": "AAO_VRCSDK3_AVATARS"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Part of #607

Note: I have excluded `.MergePhysBoneEditorModificationUtils.ts` from this PR because I should deal with `MergePhysBoneEditorModificationUtils.cs` simultaneously, and these would be completely ignored by `#if AAO_VRCSDK3_AVATARS` anyway.