### PR TITLE
Disable AnimatorParserDebugWindow if VRCSDK is not present

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Improve support of newer Unity versions `#608`
-- Improve support of projects without VRCSDK `#609`
+- Improve support of projects without VRCSDK `#609` `#625`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Improve support of newer Unity versions `#608`
-- Improve support of projects without VRCSDK `#609`
+- Improve support of projects without VRCSDK `#609` `#625`
 - AutoFreezeBlendShape will freeze BlendShapes with editor value instead of animated constant `#622`
 
 ### Security

--- a/Editor/Processors/TraceAndOptimize/AnimatorParserDebugWindow.cs
+++ b/Editor/Processors/TraceAndOptimize/AnimatorParserDebugWindow.cs
@@ -4,7 +4,6 @@ using JetBrains.Annotations;
 using nadena.dev.ndmf;
 using UnityEditor;
 using UnityEngine;
-using VRC.SDK3.Avatars.Components;
 using Object = UnityEngine.Object;
 
 namespace Anatawa12.AvatarOptimizer.Processors.TraceAndOptimizes
@@ -15,8 +14,8 @@ namespace Anatawa12.AvatarOptimizer.Processors.TraceAndOptimizes
         private static void Open() => GetWindow<AnimatorParserDebugWindow>("AnimatorParser Debug Window");
 
         public ParserSource parserSource;
-        public VRCAvatarDescriptor avatar;
         public RuntimeAnimatorController animatorController;
+        public GameObject avatar;
         public GameObject rootGameObject;
         public Motion motion;
 
@@ -133,9 +132,9 @@ namespace Anatawa12.AvatarOptimizer.Processors.TraceAndOptimizes
                     {
                         if (GUILayout.Button("Parse") && avatar)
                         {
-                            parsedRootObject = avatar.gameObject;
+                            parsedRootObject = avatar;
                             Container = new AnimatorParser(true, true).GatherAnimationModifications(
-                                new BuildContext(parsedRootObject, null));
+                                new BuildContext(avatar, null));
                         }
                     }
 


### PR DESCRIPTION
Related Issue: #607

I have to do something with AnimatorParserDebugWindow because it contains `VRCAvatarDescriptor` reference, however I don't know exactly how to deal with it.

### Case A:

This debug tool is useful for AAO users, so it is supposed work without VRCSDK.
`ParserSource.WholeAvatar` should accept something like Animator or Transform for users who wants to edit non-VRChat avatars on projects with VRCSDK. (Warning: this is a breaking change for users with VRCSDK)

### Case B: 

This is just a utility debug tool for AAO developers, so it can be safely removed if VRCSDK is not present (this PR).

### Case C:

This debug tool is legacy and would be immediately demolished. 🤯

--- 

Any thoughts?