### PR TITLE
fix: DynamicBone does not working with original DynamicBone

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Dynamic Bone support not working `#727`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Dynamic Bone support not working `#727`
 
 ### Security
 

--- a/Editor/ExternalLibraryAccessor.cs
+++ b/Editor/ExternalLibraryAccessor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -93,7 +94,6 @@ namespace Anatawa12.AvatarOptimizer
 
                 Colliders = DynamicBoneType.GetField("m_Colliders", BindingFlags.Instance | BindingFlags.Public) ??
                             throw new Exception();
-                if (Colliders.FieldType != typeof(List<>).MakeGenericType(ColliderType)) throw new Exception();
             }
 
 


### PR DESCRIPTION
なかなかSDK 2022でなくて1.6出せないので治す
