### PR TITLE
fix: freeze meaningless may cause `FreezeBlendShape:warning:animation`

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- freeze meaningless may cause `FreezeBlendShape:warning:animation` warning `#746`
 
 ### Security
 

--- a/Editor/Processors/SkinnedMeshes/InternalAutoFreezeMeaninglessBlendShapeProcessor.cs
+++ b/Editor/Processors/SkinnedMeshes/InternalAutoFreezeMeaninglessBlendShapeProcessor.cs
@@ -23,6 +23,9 @@ namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
             foreach (var vertex in target.Vertices)
                 meaninglessBlendShapes.ExceptWith(vertex.BlendShapes.Keys);
 
+            foreach (var meaninglessBlendShape in meaninglessBlendShapes)
+                context.RecordRemoveProperty(Target, $"blendShape.{meaninglessBlendShape}");
+
             var freezeBlendShape = Target.GetComponent<FreezeBlendShape>();
             var set = freezeBlendShape.shapeKeysSet.GetAsSet();
             set.UnionWith(meaninglessBlendShapes);


### PR DESCRIPTION
Fix #744 