### PR TITLE
fix: Workaround BlendShape broken bug?

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Error if there are None colliders for PhysBone `#758`
+- BlendShapes can broken in extreamly rare cases `#760`
+  - It seems this is due to Unity bug.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Error if there are None colliders for PhysBone `#758`
+- BlendShapes can broken in extreamly rare cases `#760`
+  - It seems this is due to Unity bug.
 
 ### Security
 

--- a/Editor/Processors/SkinnedMeshes/MeshInfo2.cs
+++ b/Editor/Processors/SkinnedMeshes/MeshInfo2.cs
@@ -13,6 +13,7 @@ using UnityEngine.Assertions;
 using UnityEngine.Profiling;
 using UnityEngine.Rendering;
 using Debug = System.Diagnostics.Debug;
+using Object = UnityEngine.Object;
 
 namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
 {
@@ -652,6 +653,11 @@ namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
                 var mesh = new Mesh { name = $"AAOGeneratedMesh{targetRenderer.name}" };
 
                 WriteToMesh(mesh);
+                // I don't know why but Instantiating mesh will fix broken blendshapes with
+                // https://github.com/anatawa12/AvatarOptimizer/issues/753
+                // https://booth.pm/ja/items/1054593.
+                mesh = Object.Instantiate(mesh);
+                mesh.name = $"AAOGeneratedMesh{targetRenderer.name}";
                 targetRenderer.sharedMesh = mesh;
                 for (var i = 0; i < BlendShapes.Count; i++)
                     targetRenderer.SetBlendShapeWeight(i, BlendShapes[i].weight);


### PR DESCRIPTION
I could not find root cause of this bug so I added workaround instead.

I know that
- If I instantiate the generated mesh, broken BlendShapes will be fixed
- If I duplicated the generated mesh with command + d, broken BlendShapes will be fixed
- Even if I moved `AddBlendShapeFrame`s before setting triangles, this will not be fixed

So, as a workaround, instantiate mesh to avoid this bug. I want to test this after dropping Unity 2019.

See https://github.com/anatawa12/AvatarOptimizer/issues/753

Closes #753 for now.