### PR TITLE
Fix VRM component definitions

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Fix support for UniVRM components `#802`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Fix support for UniVRM components `#802`
 
 ### Security
 

--- a/Editor/APIInternal/ComponentInfos.VRM0.cs
+++ b/Editor/APIInternal/ComponentInfos.VRM0.cs
@@ -17,6 +17,7 @@ namespace Anatawa12.AvatarOptimizer.APIInternal
         protected override void CollectDependency(VRMMeta component, ComponentDependencyCollector collector)
         {
             collector.MarkEntrypoint();
+            if (component.TryGetComponent<Animator>(out var animator)) collector.AddDependency(animator);
         }
     }
 

--- a/Editor/APIInternal/ComponentInfos.VRM0.cs
+++ b/Editor/APIInternal/ComponentInfos.VRM0.cs
@@ -26,7 +26,15 @@ namespace Anatawa12.AvatarOptimizer.APIInternal
         protected override void CollectDependency(VRMSpringBone component, ComponentDependencyCollector collector)
         {
             collector.MarkHeavyBehaviour();
-            foreach (var transform in component.GetComponentsInChildren<Transform>()) collector.AddDependency(transform);
+            foreach (var rootBone in component.RootBones)
+            {
+                foreach (var transform in rootBone.GetComponentsInChildren<Transform>())
+                {
+                    collector.AddDependency(transform, component);
+                    collector.AddDependency(transform);
+                }
+            }
+
             foreach (var collider in component.ColliderGroups) collector.AddDependency(collider);
         }
 

--- a/Editor/APIInternal/ComponentInfos.VRM1.cs
+++ b/Editor/APIInternal/ComponentInfos.VRM1.cs
@@ -22,7 +22,8 @@ namespace Anatawa12.AvatarOptimizer.APIInternal
             var avatarRootTransform = component.transform;
 
             collector.MarkEntrypoint();
-            
+            if (component.TryGetComponent<Animator>(out var animator)) collector.AddDependency(animator);
+
             // SpringBones
 
             foreach (var spring in component.SpringBone.Springs)


### PR DESCRIPTION
I don't know whether this branch should be based on `master` or `master-1.6`, so tell me when I need a rebase 😃

- #711 but for VRM0 / VRM1 (Animator component is optional if you don't care animating Humanoid muscles in Unity Editor, which is mostly true if you are just building VRM files with UniVRM)
- VRMSpringBone of VRM0 animates `VRMSpringBone.RootBones`, not children of VRMSpringBone component