### PR TITLE
Fix: Treat VRM0 BlendShapeProxy as EntryPoint

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Reference to meshes will be merged is removed `#808`
+- VRM: Fix MergeSkinnedMesh breaking BlendShapeClip / VRM10Expression `#810`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Fix support for UniVRM components `#802`
+- VRM: Fix MergeSkinnedMesh breaking BlendShapeClip / VRM10Expression `#810`
 
 ### Security
 

--- a/Editor/APIInternal/ComponentInfos.VRM0.cs
+++ b/Editor/APIInternal/ComponentInfos.VRM0.cs
@@ -59,23 +59,10 @@ namespace Anatawa12.AvatarOptimizer.APIInternal
     {
         protected override void CollectDependency(VRMBlendShapeProxy component, ComponentDependencyCollector collector)
         {
-            var avatarRootTransform = component.transform;
-
-            collector.MarkHeavyBehaviour();
-            foreach (var clip in component.BlendShapeAvatar.Clips)
-            {
-                foreach (var binding in clip.Values)
-                {
-                    var target = avatarRootTransform.Find(binding.RelativePath);
-                    collector.AddDependency(target, component);
-                    collector.AddDependency(target);
-                }
-                foreach (var materialBinding in clip.MaterialValues)
-                {
-                    // TODO: I don't know what to do with BlendShape materials, so I pretend material names does not change (ex. MergeToonLitMaterial)
-                }
-            }
+            if (component.BlendShapeAvatar) collector.MarkEntrypoint();
         }
+
+        // BlendShape / Material mutations are collected through AnimatorParser, once we start tracking material changes
     }
 
     [ComponentInformation(typeof(VRMLookAtHead))]

--- a/Editor/APIInternal/ComponentInfos.VRM1.cs
+++ b/Editor/APIInternal/ComponentInfos.VRM1.cs
@@ -34,24 +34,6 @@ namespace Anatawa12.AvatarOptimizer.APIInternal
             
             // Expressions
             
-            foreach (var clip in component.Vrm.Expression.Clips.Select(c => c.Clip))
-            {
-                foreach (var binding in clip.MorphTargetBindings)
-                {
-                    var target = avatarRootTransform.Find(binding.RelativePath);
-                    collector.AddDependency(target, component);
-                    collector.AddDependency(target);
-                }
-                foreach (var materialUVBinding in clip.MaterialUVBindings)
-                {
-                    // TODO: I don't know what to do with BlendShape materials, so I pretend material names does not change (ex. MergeToonLitMaterial)
-                }
-                foreach (var materialColorBinding in clip.MaterialColorBindings)
-                {
-                    // TODO: I don't know what to do with BlendShape materials, so I pretend material names does not change (ex. MergeToonLitMaterial)
-                }
-            }
-
             // First Person and LookAt
             // NOTE: these dependencies are satisfied by either Animator or Humanoid 
             // collector.AddDependency(GetBoneTransformForVrm10(component, HumanBodyBones.Head));
@@ -78,6 +60,7 @@ namespace Anatawa12.AvatarOptimizer.APIInternal
             }
 
             // Expressions
+            // BlendShape / Material mutations are collected through AnimatorParser, once we start tracking material changes
 
             // First Person and LookAt
             if (component.Vrm.LookAt.LookAtType == LookAtType.bone)

--- a/Editor/AnimatorParsers/AnimatorParser.cs
+++ b/Editor/AnimatorParsers/AnimatorParser.cs
@@ -390,6 +390,10 @@ namespace Anatawa12.AvatarOptimizer.AnimatorParsers
                 modificationsContainer.ModifyObject(skinnedMeshRenderer)
                     .AddModificationAsNewLayer(blendShapePropName, AnimationFloatProperty.Variable(source));
             }
+            
+            // Currently, MaterialValueBindings are guaranteed to not change (MaterialName, in particular)
+            // unless MergeToonLitMaterial is used, which breaks material animations anyway.
+            // Gather material modifications here once we start tracking material changes...
         }
 #endif
 
@@ -406,6 +410,10 @@ namespace Anatawa12.AvatarOptimizer.AnimatorParsers
                 modificationsContainer.ModifyObject(skinnedMeshRenderer)
                     .AddModificationAsNewLayer(blendShapePropName, AnimationFloatProperty.Variable(source));
             }
+
+            // Currently, MaterialValueBindings are guaranteed to not change (MaterialName, in particular)
+            // unless MergeToonLitMaterial is used, which breaks material animations anyway.
+            // Gather material modifications here once we start tracking material changes...
         }
 #endif
         

--- a/Editor/ObjectMapping/ObjectMappingContext.cs
+++ b/Editor/ObjectMapping/ObjectMappingContext.cs
@@ -285,6 +285,9 @@ namespace Anatawa12.AvatarOptimizer
                             Weight = binding.Weight
                         });
                 }).ToArray(); 
+                // Currently, MaterialValueBindings are guaranteed to not change (MaterialName, in particular)
+                // unless MergeToonLitMaterial is used, which breaks material animations anyway.
+                // Map MaterialValues here once we start tracking material changes...
                 return newBlendShapeClip;
             }
 #endif
@@ -310,6 +313,9 @@ namespace Anatawa12.AvatarOptimizer
                             Weight = binding.Weight
                         });
                 }).ToArray(); 
+                // Currently, MaterialColorBindings and MaterialUVBindings are guaranteed to not change (MaterialName, in particular)
+                // unless MergeToonLitMaterial is used, which breaks material animations anyway.
+                // Map MaterialColorBindings / MaterialUVBindings here once we start tracking material changes...
                 return newVrm10Expression;
             }
 #endif


### PR DESCRIPTION
Fix #809 by marking VRM0 `BlendShapeProxy` as EntryPoint, just like `Animator`.
(VRM1 counterpart, `Vrm10Instance`, is already EntryPoint.)
We should not access `Component.transform` here anyway, because avatar processing is at an intermediate state when FindUnusedObjects is collecting dependencies.

Also I have made an assumption that AvatarOptimizer does not change Material names or remap parameter values, except when MergeToonLitMaterial is used.
(I didn't mark these comments as TODOs because I doubt "tracking material changes" would happen in near future.)