### PR TITLE
chore(deps): upgrade minimum vrcsdk to 3.3.0

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog].
     - Converts Entry / Exit to 1D BlendTree `#854` `#867`
     - Merges multiple Direct BlendTree to single Direct BlendTree `#870`
     - Removes meaningless Animator Layers `#870`
-
+f
 ### Changed
 - MergePhysBone now corrects curve settings `#775`
 - MergePhysBone now warns if chain length are not same `#775`
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog].
   - That's unnecessary (incorrect I think) and force users to remove or change the clip when user wants to face shape.
   - I see AAO users use `FreezeBlendShapes` for overriding such a blendshapes on twitter.
   - I think using this way is reasonable enough so I suppressed the warning if AAO detected such a usage.
+- Minimum VRCSDK to 3.3.0 `#882`
+  - VRCSDK 3.3.0 is required for stable NDMF-VRCSDK compatibility.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog].
   - That's unnecessary (incorrect I think) and force users to remove or change the clip when user wants to face shape.
   - I see AAO users use `FreezeBlendShapes` for overriding such a blendshapes on twitter.
   - I think using this way is reasonable enough so I suppressed the warning if AAO detected such a usage.
+- Changed minimum VRCSDK to 3.3.0 `#882`
+  - VRCSDK 3.3.0 is required for stable NDMF-VRCSDK compatibility.
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "license": "MIT",
   "vpmDependencies": {
     "nadena.dev.ndmf": "^1.3.0",
-    "com.vrchat.avatars": ">=3.2.0-beta.1 <3.6.0"
+    "com.vrchat.avatars": ">=3.3.0 <3.6.0"
   }
 }


### PR DESCRIPTION
VRCSDK with public api is almost required for stable ndmf-vrcsdk compatibility.