### PR TITLE
fix: Fix VRM support

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog].
   - It's not expected to have behavior change, but if you found some, please report it.
 - Re-fix Nested Constraint can be broken with Trace and Optimize `#880`
 - Fix non-VRChat project support `#884`
+- Fix VRM support `#892`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog].
   - It's not expected to have behavior change, but if you found some, please report it.
 - Re-fix Nested Constraint can be broken with Trace and Optimize `#880`
 - Fix non-VRChat project support `#884`
+- Fix VRM support `#892`
 
 ### Security
 

--- a/Editor/AnimatorParserV2/AnimatorParser.cs
+++ b/Editor/AnimatorParserV2/AnimatorParser.cs
@@ -304,7 +304,7 @@ namespace Anatawa12.AvatarOptimizer.AnimatorParsersV2
             var nodes = new ComponentNodeContainer();
 
             var bindings = vrmBlendShapeProxy.BlendShapeAvatar.Clips.SelectMany(clip => clip.Values);
-            foreach (var binding in bindings)
+            foreach (var binding in bindings.Select(binding => (binding.RelativePath, binding.Index)).Distinct())
             {
                 var skinnedMeshRenderer =
                     context.AvatarRootTransform.Find(binding.RelativePath).GetComponent<SkinnedMeshRenderer>();
@@ -327,7 +327,7 @@ namespace Anatawa12.AvatarOptimizer.AnimatorParsersV2
             var nodes = new ComponentNodeContainer();
 
             var bindings = vrm10Instance.Vrm.Expression.Clips.SelectMany(clip => clip.Clip.MorphTargetBindings);
-            foreach (var binding in bindings)
+            foreach (var binding in bindings.Select(binding => (binding.RelativePath, binding.Index)).Distinct())
             {
                 var skinnedMeshRenderer = 
                     context.AvatarRootTransform.Find(binding.RelativePath).GetComponent<SkinnedMeshRenderer>();

--- a/Editor/Processors/AnimatorOptimizer/AnimOptPassBase.cs
+++ b/Editor/Processors/AnimatorOptimizer/AnimOptPassBase.cs
@@ -141,7 +141,7 @@ namespace Anatawa12.AvatarOptimizer.Processors.AnimatorOptimizer
 #if AAO_VRCSDK3_AVATARS
             {
                 var descriptor = context.AvatarDescriptor;
-                if (descriptor.customizeAnimationLayers)
+                if (descriptor && descriptor.customizeAnimationLayers)
                 {
                     foreach (var playableLayer in descriptor.baseAnimationLayers)
                     {


### PR DESCRIPTION
- VRM には AvatarDescriptor はない
- 表情（ VRM0 の BlendShapeClip / VRM1 の Expression ）が操作する対象の BlendShape は普通に重複しうる
  - `(target, prop)` が重複すると `ComponentNodeContainer.Add()` が失敗する
  - 「複数の表情が同じ BlendShape を操作する」は普通にあり得る
    - このパターンの場合、 NodeContainer や PropModeNode を真面目に書いていた可能性がある
  - 実際は「一つの表情で同じ BlendShape を複数回操作するデータが作れる」（ VRM は特に重複チェックをしていない）ので、大元で重複チェックすれば良いでしょうという感じになりました