### PR TITLE
feat: implement mask texture editor

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 ### Added
+- Implement mask texture editor [`#1044`](https://github.com/anatawa12/AvatarOptimizer/pull/1044)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 ### Added
+- Implement mask texture editor [`#1044`](https://github.com/anatawa12/AvatarOptimizer/pull/1044)
 
 ### Changed
 

--- a/Editor/EditModePreview/MeshPreviewController.cs
+++ b/Editor/EditModePreview/MeshPreviewController.cs
@@ -15,6 +15,8 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
     {
         [CanBeNull] private RemoveMeshPreviewController _previewController;
         public static bool Previewing => instance.previewing;
+        public static Mesh PreviewMesh => instance.previewMesh;
+        public static Mesh OriginalMesh => instance.originalMesh;
 
         [SerializeField] private bool previewing;
         [SerializeField] [CanBeNull] private Mesh previewMesh;

--- a/Editor/EditModePreview/RemoveMeshPreviewController.cs
+++ b/Editor/EditModePreview/RemoveMeshPreviewController.cs
@@ -232,7 +232,7 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
 
             if (_removeMeshByMask.Value != null && MaskTextureEditor.Window.IsOpen(_targetRenderer.Value))
             {
-                var instanceId = EditorWindow.GetWindow<MaskTextureEditor.Window>().PreviewTexture.GetInstanceID();
+                var instanceId = MaskTextureEditor.Window.Instance.PreviewTexture.GetInstanceID();
                 if (_maskTextureEditorWindowPreviewTextureInstanceId != instanceId)
                 {
                     _maskTextureEditorWindowPreviewTextureInstanceId = instanceId;
@@ -301,7 +301,7 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
                                 if (submeshInfo.enabled)
                                 {
                                     var maskTexture = MaskTextureEditor.Window.IsOpen(_targetRenderer.Value, subMeshIdx)
-                                        ? EditorWindow.GetWindow<MaskTextureEditor.Window>().PreviewTexture
+                                        ? MaskTextureEditor.Window.Instance.PreviewTexture
                                         : submeshInfo.mask;
                                     var mode = submeshInfo.mode;
                                     if (maskTexture != null && maskTexture.isReadable)

--- a/Editor/EditModePreview/RemoveMeshPreviewController.cs
+++ b/Editor/EditModePreview/RemoveMeshPreviewController.cs
@@ -39,6 +39,7 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
             _removeMeshInBox = default;
             _removeMeshByBlendShape = default;
             _removeMeshByMask = default;
+            _maskTextureEditorWindowPreviewTextureInstanceId = default;
 
             var subMeshes = new SubMeshDescriptor[OriginalMesh.subMeshCount];
             _subMeshTriangleEndIndices = new int[OriginalMesh.subMeshCount];
@@ -99,6 +100,7 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
         private ComponentHolder<RemoveMeshInBox> _removeMeshInBox;
         private ComponentHolder<RemoveMeshByBlendShape> _removeMeshByBlendShape;
         private ComponentHolder<RemoveMeshByMask> _removeMeshByMask;
+        private int _maskTextureEditorWindowPreviewTextureInstanceId = default;
 
         private readonly BlendShapePreviewContext _blendShapePreviewContext;
         private readonly int[] _subMeshTriangleEndIndices;
@@ -228,6 +230,21 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
                     break;
             }
 
+            if (_removeMeshByMask.Value != null && MaskTextureEditor.Window.IsOpen(_targetRenderer.Value))
+            {
+                var instanceId = EditorWindow.GetWindow<MaskTextureEditor.Window>().PreviewTexture.GetInstanceID();
+                if (_maskTextureEditorWindowPreviewTextureInstanceId != instanceId)
+                {
+                    _maskTextureEditorWindowPreviewTextureInstanceId = instanceId;
+                    modified = true;
+                }
+            }
+            else if (_maskTextureEditorWindowPreviewTextureInstanceId != default)
+            {
+                _maskTextureEditorWindowPreviewTextureInstanceId = default;
+                modified = true;
+            }
+
             if (modified)
                 UpdatePreviewMesh();
 
@@ -283,7 +300,9 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
                                 var submeshInfo = materials[subMeshIdx];
                                 if (submeshInfo.enabled)
                                 {
-                                    var maskTexture = submeshInfo.mask;
+                                    var maskTexture = MaskTextureEditor.Window.IsOpen(_targetRenderer.Value, subMeshIdx)
+                                        ? EditorWindow.GetWindow<MaskTextureEditor.Window>().PreviewTexture
+                                        : submeshInfo.mask;
                                     var mode = submeshInfo.mode;
                                     if (maskTexture != null && maskTexture.isReadable)
                                     {

--- a/Editor/Inspector/RemoveMeshByMaskEditor.cs
+++ b/Editor/Inspector/RemoveMeshByMaskEditor.cs
@@ -54,9 +54,7 @@ namespace Anatawa12.AvatarOptimizer
                         EditorGUI.indentLevel++;
                         var mask = slotConfig.FindPropertyRelative(nameof(RemoveMeshByMask.MaterialSlot.mask));
                         var mode = slotConfig.FindPropertyRelative(nameof(RemoveMeshByMask.MaterialSlot.mode));
-
-                        EditorGUILayout.PropertyField(mask);
-                        EditorGUILayout.PropertyField(mode);
+                        MaskTextureEditor.Inspector.DrawFields(_renderer, i, mask, mode);
                         var texture = mask.objectReferenceValue as Texture2D;
                         if (texture == null)
                         {

--- a/Editor/MaskTextureEditor.meta
+++ b/Editor/MaskTextureEditor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26f9d77060a8fea49a1d5f2960943360
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaskTextureEditor/Inspector.cs
+++ b/Editor/MaskTextureEditor/Inspector.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
+{
+    internal static class Inspector
+    {
+        private readonly static Vector2 DefaultTextureSize = new Vector2(1024.0f, 1024.0f);
+
+        public static void DrawFields(
+            SkinnedMeshRenderer renderer, int subMesh,
+            SerializedProperty mask,
+            SerializedProperty mode)
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.PropertyField(mask);
+
+                var texture = mask.objectReferenceValue as Texture2D;
+                if (texture == null)
+                {
+                    if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:create"), GUILayout.ExpandWidth(false)))
+                    {
+                        mask.serializedObject.Update();
+
+                        switch ((RemoveMeshByMask.RemoveMode)mode.intValue)
+                        {
+                            case RemoveMeshByMask.RemoveMode.RemoveBlack:
+                                mask.objectReferenceValue = CreateTexture(DefaultTextureSize, Color.white);
+                                break;
+                            case RemoveMeshByMask.RemoveMode.RemoveWhite:
+                                mask.objectReferenceValue = CreateTexture(DefaultTextureSize, Color.black);
+                                break;
+                        }
+
+                        mask.serializedObject.ApplyModifiedProperties();
+
+                        // Exit GUI to avoid "EndLayoutGroup: BeginLayoutGroup must be called first."
+                        GUIUtility.ExitGUI();
+                    }
+                }
+                else
+                {
+                    var isOpen = Window.IsOpen(renderer, subMesh, texture);
+                    var shouldOpen = GUILayout.Toggle(isOpen,
+                        AAOL10N.Tr("MaskTextureEditor:edit"),
+                        GUI.skin.button, GUILayout.ExpandWidth(false));
+                    if (isOpen != shouldOpen)
+                    {
+                        if (EditorWindow.HasOpenInstances<Window>())
+                        {
+                            EditorWindow.GetWindow<Window>().Close();
+                        }
+                        if (shouldOpen)
+                        {
+                            EditorWindow.GetWindow<Window>().Open(renderer, subMesh, texture);
+                        }
+                    }
+                }
+            }
+
+            EditorGUILayout.PropertyField(mode);
+        }
+
+        private static Texture2D CreateTexture(Vector2 size, Color color)
+        {
+            var path = EditorUtility.SaveFilePanelInProject(
+                AAOL10N.Tr("MaskTextureEditor:create"),
+                string.Empty, "png", string.Empty);
+
+            if (string.IsNullOrEmpty(path))
+            {
+                return null;
+            }
+
+            var painter = ScriptableObject.CreateInstance<TexturePainter>();
+            painter.Init(size, color);
+
+            var texture = new Texture2D(0, 0);
+            painter.Save(texture);
+
+            try
+            {
+                File.WriteAllBytes(path, texture.EncodeToPNG());
+
+                AssetDatabase.ImportAsset(path);
+
+                var importer = AssetImporter.GetAtPath(path) as TextureImporter;
+                importer.isReadable = true;
+                importer.SaveAndReimport();
+
+                return AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+            }
+            catch (Exception e)
+            {
+                EditorUtility.DisplayDialog(
+                    AAOL10N.Tr("MaskTextureEditor:errorTitle"),
+                    AAOL10N.Tr("MaskTextureEditor:errorMessageCreateFailed"),
+                    AAOL10N.Tr("MaskTextureEditor:errorButton"));
+
+                Debug.LogError(e);
+            }
+            finally
+            {
+                Object.DestroyImmediate(painter);
+                Object.DestroyImmediate(texture);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Editor/MaskTextureEditor/Inspector.cs
+++ b/Editor/MaskTextureEditor/Inspector.cs
@@ -103,7 +103,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 EditorUtility.DisplayDialog(
                     AAOL10N.Tr("MaskTextureEditor:errorTitle"),
                     AAOL10N.Tr("MaskTextureEditor:errorMessageCreateFailed"),
-                    AAOL10N.Tr("MaskTextureEditor:errorButton"));
+                    "OK");
 
                 Debug.LogError(e);
             }

--- a/Editor/MaskTextureEditor/Inspector.cs
+++ b/Editor/MaskTextureEditor/Inspector.cs
@@ -55,12 +55,15 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                         {
                             if (EditorWindow.HasOpenInstances<Window>())
                             {
-                                EditorWindow.GetWindow<Window>().Close();
+                                EditorWindow.GetWindow<Window>().SafeClose();
                             }
-                            if (shouldOpen)
+                            if (shouldOpen && !EditorWindow.HasOpenInstances<Window>())
                             {
                                 EditorWindow.GetWindow<Window>().Open(renderer, subMesh, texture);
                             }
+
+                            // Exit GUI to avoid "EndLayoutGroup: BeginLayoutGroup must be called first."
+                            GUIUtility.ExitGUI();
                         }
                     }
                 }

--- a/Editor/MaskTextureEditor/Inspector.cs
+++ b/Editor/MaskTextureEditor/Inspector.cs
@@ -44,19 +44,23 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 }
                 else
                 {
-                    var isOpen = Window.IsOpen(renderer, subMesh, texture);
-                    var shouldOpen = GUILayout.Toggle(isOpen,
-                        AAOL10N.Tr("MaskTextureEditor:edit"),
-                        GUI.skin.button, GUILayout.ExpandWidth(false));
-                    if (isOpen != shouldOpen)
+                    var extension = Path.GetExtension(AssetDatabase.GetAssetPath(texture));
+                    using (new EditorGUI.DisabledScope(extension != ".png"))
                     {
-                        if (EditorWindow.HasOpenInstances<Window>())
+                        var isOpen = Window.IsOpen(renderer, subMesh, texture);
+                        var shouldOpen = GUILayout.Toggle(isOpen,
+                            AAOL10N.Tr("MaskTextureEditor:edit"),
+                            GUI.skin.button, GUILayout.ExpandWidth(false));
+                        if (isOpen != shouldOpen)
                         {
-                            EditorWindow.GetWindow<Window>().Close();
-                        }
-                        if (shouldOpen)
-                        {
-                            EditorWindow.GetWindow<Window>().Open(renderer, subMesh, texture);
+                            if (EditorWindow.HasOpenInstances<Window>())
+                            {
+                                EditorWindow.GetWindow<Window>().Close();
+                            }
+                            if (shouldOpen)
+                            {
+                                EditorWindow.GetWindow<Window>().Open(renderer, subMesh, texture);
+                            }
                         }
                     }
                 }

--- a/Editor/MaskTextureEditor/Inspector.cs
+++ b/Editor/MaskTextureEditor/Inspector.cs
@@ -8,7 +8,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
 {
     internal static class Inspector
     {
-        private readonly static Vector2 DefaultTextureSize = new Vector2(1024.0f, 1024.0f);
+        private readonly static Vector2Int DefaultTextureSize = new Vector2Int(1024, 1024);
 
         public static void DrawFields(
             SkinnedMeshRenderer renderer, int subMesh,
@@ -65,7 +65,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
             EditorGUILayout.PropertyField(mode);
         }
 
-        private static Texture2D CreateTexture(Vector2 size, Color color)
+        private static Texture2D CreateTexture(Vector2Int size, Color color)
         {
             var path = EditorUtility.SaveFilePanelInProject(
                 AAOL10N.Tr("MaskTextureEditor:create"),

--- a/Editor/MaskTextureEditor/Inspector.cs
+++ b/Editor/MaskTextureEditor/Inspector.cs
@@ -17,11 +17,11 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
         {
             using (new EditorGUILayout.HorizontalScope())
             {
-                EditorGUILayout.PropertyField(mask);
-
                 var texture = mask.objectReferenceValue as Texture2D;
                 if (texture == null)
                 {
+                    EditorGUILayout.PropertyField(mask);
+
                     if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:create"), GUILayout.ExpandWidth(false)))
                     {
                         mask.serializedObject.Update();
@@ -44,20 +44,25 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 }
                 else
                 {
+                    var isOpenWindow = Window.IsOpen(renderer, subMesh);
+                    using (new EditorGUI.DisabledScope(isOpenWindow))
+                    {
+                        EditorGUILayout.PropertyField(mask);
+                    }
+
                     var extension = Path.GetExtension(AssetDatabase.GetAssetPath(texture));
                     using (new EditorGUI.DisabledScope(extension != ".png"))
                     {
-                        var isOpen = Window.IsOpen(renderer, subMesh, texture);
-                        var shouldOpen = GUILayout.Toggle(isOpen,
+                        var shouldOpenWindow = GUILayout.Toggle(isOpenWindow,
                             AAOL10N.Tr("MaskTextureEditor:edit"),
                             GUI.skin.button, GUILayout.ExpandWidth(false));
-                        if (isOpen != shouldOpen)
+                        if (isOpenWindow != shouldOpenWindow)
                         {
                             if (EditorWindow.HasOpenInstances<Window>())
                             {
                                 EditorWindow.GetWindow<Window>().SafeClose();
                             }
-                            if (shouldOpen && !EditorWindow.HasOpenInstances<Window>())
+                            if (shouldOpenWindow && !EditorWindow.HasOpenInstances<Window>())
                             {
                                 EditorWindow.GetWindow<Window>().Open(renderer, subMesh, texture);
                             }

--- a/Editor/MaskTextureEditor/Inspector.cs.meta
+++ b/Editor/MaskTextureEditor/Inspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f716c26dcfc98384e862453af3342b4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaskTextureEditor/Shaders.meta
+++ b/Editor/MaskTextureEditor/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfce59c3b6550aa4eb4d046f7dcb4445
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaskTextureEditor/Shaders/Fill.shader
+++ b/Editor/MaskTextureEditor/Shaders/Fill.shader
@@ -1,0 +1,37 @@
+Shader "Hidden/MaskTextureEditor/Fill"
+{
+    Properties
+    {
+        _Color("Color", Color) = (1.0, 1.0, 1.0, 1.0)
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Opaque"
+        }
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            float4 _Color;
+
+            float4 vert(float4 v : POSITION) : SV_POSITION
+            {
+                return UnityObjectToClipPos(v);
+            }
+
+            float4 frag() : SV_Target
+            {
+                return _Color;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Editor/MaskTextureEditor/Shaders/Fill.shader
+++ b/Editor/MaskTextureEditor/Shaders/Fill.shader
@@ -1,4 +1,4 @@
-Shader "Hidden/MaskTextureEditor/Fill"
+Shader "Hidden/AvatarOptimizer/MaskTextureEditor/Fill"
 {
     Properties
     {

--- a/Editor/MaskTextureEditor/Shaders/Fill.shader.meta
+++ b/Editor/MaskTextureEditor/Shaders/Fill.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e26fa82c42ec6404b927e1a0c0f3ffe6
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaskTextureEditor/Shaders/Inverse.shader
+++ b/Editor/MaskTextureEditor/Shaders/Inverse.shader
@@ -1,0 +1,54 @@
+Shader "Hidden/MaskTextureEditor/Inverse"
+{
+    Properties
+    {
+        _MainTex("Texture", 2D) = "white" {}
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Opaque"
+        }
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float4 color = tex2D(_MainTex, i.uv);
+                return float4(1.0 - color.rgb, color.a);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Editor/MaskTextureEditor/Shaders/Inverse.shader
+++ b/Editor/MaskTextureEditor/Shaders/Inverse.shader
@@ -1,4 +1,4 @@
-Shader "Hidden/MaskTextureEditor/Inverse"
+Shader "Hidden/AvatarOptimizer/MaskTextureEditor/Inverse"
 {
     Properties
     {

--- a/Editor/MaskTextureEditor/Shaders/Inverse.shader.meta
+++ b/Editor/MaskTextureEditor/Shaders/Inverse.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9690e8f230ceba845afb23f277f4ef54
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaskTextureEditor/Shaders/Paint.shader
+++ b/Editor/MaskTextureEditor/Shaders/Paint.shader
@@ -1,4 +1,4 @@
-Shader "Hidden/MaskTextureEditor/Paint"
+Shader "Hidden/AvatarOptimizer/MaskTextureEditor/Paint"
 {
     Properties
     {

--- a/Editor/MaskTextureEditor/Shaders/Paint.shader
+++ b/Editor/MaskTextureEditor/Shaders/Paint.shader
@@ -1,0 +1,68 @@
+Shader "Hidden/MaskTextureEditor/Paint"
+{
+    Properties
+    {
+        _MainTex("Texture", 2D) = "white" {}
+        _BrushLine("Brush Line", Vector) = (0.5, 0.5, 0.5, 0.5)
+        _BrushSize("Brush Size", Float) = 100.0
+        _BrushColor("Brush Color", Color) = (1.0, 1.0, 1.0, 1.0)
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Opaque"
+        }
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float4 _MainTex_TexelSize;
+            
+            float4 _BrushLine;
+            float _BrushSize;
+            float4 _BrushColor;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float2 a = _BrushLine.xy * _MainTex_TexelSize.xy;
+                float2 b = _BrushLine.zw * _MainTex_TexelSize.xy;
+                float r = _BrushSize * _MainTex_TexelSize.xy * 0.5;
+                float d =
+                    dot(i.uv - a, b - a) <= 0 ? distance(i.uv, a) :
+                    dot(i.uv - b, a - b) <= 0 ? distance(i.uv, b) :
+                    abs((i.uv - a).x * (b - a).y - (i.uv - a).y * (b - a).x) / distance(a, b);
+                return lerp(tex2D(_MainTex, i.uv), _BrushColor, d < r);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Editor/MaskTextureEditor/Shaders/Paint.shader.meta
+++ b/Editor/MaskTextureEditor/Shaders/Paint.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b3225a45112500e48a551d13b88fbb76
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaskTextureEditor/TexturePainter.cs
+++ b/Editor/MaskTextureEditor/TexturePainter.cs
@@ -44,24 +44,24 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
 
         public void Init(Texture2D texture)
         {
-            Init(Vector2.zero);
+            Init();
             Load(texture);
         }
 
-        public void Init(Vector2 size, Color color)
+        public void Init(Vector2Int size, Color color)
         {
             Init(size);
             Fill(color);
         }
 
-        private void Init(Vector2 size)
+        private void Init(Vector2Int size = default)
         {
             // Set HideFlags to keep the state when reloading a scene or domain
-            _target = new RenderTexture((int)size.x, (int)size.y, 0)
+            _target = new RenderTexture(size.x, size.y, 0)
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };
-            _buffer = new RenderTexture((int)size.x, (int)size.y, 0)
+            _buffer = new RenderTexture(size.x, size.y, 0)
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };

--- a/Editor/MaskTextureEditor/TexturePainter.cs
+++ b/Editor/MaskTextureEditor/TexturePainter.cs
@@ -1,0 +1,186 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
+{
+    internal class TexturePainter : ScriptableObject
+    {
+        private readonly static int ColorPropertyId = Shader.PropertyToID("_Color");
+        private readonly static int BrushLinePropertyId = Shader.PropertyToID("_BrushLine");
+        private readonly static int BrushSizePropertyId = Shader.PropertyToID("_BrushSize");
+        private readonly static int BrushColorPropertyId = Shader.PropertyToID("_BrushColor");
+
+        [SerializeField]
+        private float _brushSize = 100.0f;
+
+        [SerializeField]
+        private Color _brushColor = Color.black;
+
+        [SerializeField]
+        private RenderTexture _target = null;
+
+        [SerializeField]
+        private RenderTexture _buffer = null;
+
+        [SerializeField]
+        private Material _fillMaterial = null;
+
+        [SerializeField]
+        private Material _paintMaterial = null;
+
+        [SerializeField]
+        private Material _inverseMaterial = null;
+
+        public float BrushSize { get => _brushSize; set => _brushSize = value; }
+        public Color BrushColor { get => _brushColor; set => _brushColor = value; }
+        public RenderTexture Texture => _target;
+        public Vector2 TextureSize => new Vector2(_target.width, _target.height);
+
+        private void Awake()
+        {
+            // Set HideFlags to keep the state when reloading a scene or domain
+            hideFlags = HideFlags.HideAndDontSave;
+        }
+
+        public void Init(Texture2D texture)
+        {
+            Init(Vector2.zero);
+            Load(texture);
+        }
+
+        public void Init(Vector2 size, Color color)
+        {
+            Init(size);
+            Fill(color);
+        }
+
+        private void Init(Vector2 size)
+        {
+            // Set HideFlags to keep the state when reloading a scene or domain
+            _target = new RenderTexture((int)size.x, (int)size.y, 0)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            _buffer = new RenderTexture((int)size.x, (int)size.y, 0)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            _fillMaterial = new Material(Shader.Find("Hidden/MaskTextureEditor/Fill"))
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            _paintMaterial = new Material(Shader.Find("Hidden/MaskTextureEditor/Paint"))
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            _inverseMaterial = new Material(Shader.Find("Hidden/MaskTextureEditor/Inverse"))
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+        }
+
+        public void Draw(Rect rect)
+        {
+            // Draw the texture
+            GUI.DrawTexture(rect, _target);
+
+            // Draw the brush
+            Handles.color = GUI.color * _brushColor;
+            Handles.matrix = Matrix4x4.TRS(
+                Event.current.mousePosition,
+                Quaternion.identity,
+                _brushSize * rect.size / TextureSize);
+            Handles.DrawSolidDisc(Vector3.zero, Vector3.forward, 0.5f);
+            Handles.matrix = Matrix4x4.identity;
+        }
+
+        public void Load(Texture2D texture)
+        {
+            _target.Release();
+            _target.width = texture.width;
+            _target.height = texture.height;
+            _target.Create();
+
+            _buffer.Release();
+            _buffer.width = texture.width;
+            _buffer.height = texture.height;
+            _buffer.Create();
+
+            Graphics.Blit(texture, _target);
+            RenderTexture.active = null;
+        }
+
+        public void Save(Texture2D texture)
+        {
+            RenderTexture.active = _target;
+
+#if UNITY_2021_2_OR_NEWER
+            texture.Reinitialize(_target.width, _target.height);
+#else
+            texture.Resize(_target.width, _target.height);
+#endif
+            texture.ReadPixels(new Rect(Vector2.zero, TextureSize), 0, 0);
+            texture.Apply();
+
+            RenderTexture.active = null;
+        }
+
+        public void Fill(Color color)
+        {
+            _fillMaterial.SetColor(ColorPropertyId, color);
+
+            Graphics.Blit(_target, _buffer);
+            Graphics.Blit(_buffer, _target, _fillMaterial);
+            RenderTexture.active = null;
+        }
+
+        public void Paint(Vector2 positionA, Vector2 positionB)
+        {
+            _paintMaterial.SetVector(BrushLinePropertyId, new Vector4(
+                positionA.x, TextureSize.y - positionA.y,
+                positionB.x, TextureSize.y - positionB.y));
+            _paintMaterial.SetFloat(BrushSizePropertyId, _brushSize);
+            _paintMaterial.SetColor(BrushColorPropertyId, _brushColor);
+
+            Graphics.Blit(_target, _buffer);
+            Graphics.Blit(_buffer, _target, _paintMaterial);
+            RenderTexture.active = null;
+        }
+
+        public void Inverse()
+        {
+            Graphics.Blit(_target, _buffer);
+            Graphics.Blit(_buffer, _target, _inverseMaterial);
+            RenderTexture.active = null;
+        }
+
+        private void OnDestroy()
+        {
+            if (_target != null)
+            {
+                DestroyImmediate(_target);
+                _target = null;
+            }
+            if (_buffer != null)
+            {
+                DestroyImmediate(_buffer);
+                _buffer = null;
+            }
+            if (_fillMaterial != null)
+            {
+                DestroyImmediate(_fillMaterial);
+                _fillMaterial = null;
+            }
+            if (_paintMaterial != null)
+            {
+                DestroyImmediate(_paintMaterial);
+                _paintMaterial = null;
+            }
+            if (_inverseMaterial != null)
+            {
+                DestroyImmediate(_inverseMaterial);
+                _inverseMaterial = null;
+            }
+        }
+    }
+}

--- a/Editor/MaskTextureEditor/TexturePainter.cs
+++ b/Editor/MaskTextureEditor/TexturePainter.cs
@@ -65,15 +65,15 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };
-            _fillMaterial = new Material(Shader.Find("Hidden/MaskTextureEditor/Fill"))
+            _fillMaterial = new Material(Shader.Find("Hidden/AvatarOptimizer/MaskTextureEditor/Fill"))
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };
-            _paintMaterial = new Material(Shader.Find("Hidden/MaskTextureEditor/Paint"))
+            _paintMaterial = new Material(Shader.Find("Hidden/AvatarOptimizer/MaskTextureEditor/Paint"))
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };
-            _inverseMaterial = new Material(Shader.Find("Hidden/MaskTextureEditor/Inverse"))
+            _inverseMaterial = new Material(Shader.Find("Hidden/AvatarOptimizer/MaskTextureEditor/Inverse"))
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };

--- a/Editor/MaskTextureEditor/TexturePainter.cs.meta
+++ b/Editor/MaskTextureEditor/TexturePainter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62cda37c90b605d4f89417c5f85bf05e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaskTextureEditor/TextureUndoStack.cs
+++ b/Editor/MaskTextureEditor/TextureUndoStack.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
+{
+    internal class TextureUndoStack : ScriptableObject
+    {
+        private class Counter : ScriptableObject
+        {
+            [SerializeField]
+            private int _count = 0;
+
+            public int Count { get => _count; set => _count = value; }
+
+            private void Awake()
+            {
+                // Set HideFlags to keep the state when reloading a scene or domain
+                hideFlags = HideFlags.HideAndDontSave;
+            }
+        }
+
+        [SerializeField]
+        private RenderTexture _target = null;
+
+        [SerializeField]
+        private List<RenderTexture> _stack = null;
+
+        [SerializeField]
+        private Counter _counter = null;
+
+        public bool CanUndo => _counter.Count > 1;
+        public bool CanRedo => _counter.Count < _stack.Count;
+
+        private void Awake()
+        {
+            // Set HideFlags to keep the state when reloading a scene or domain
+            hideFlags = HideFlags.HideAndDontSave;
+        }
+
+        private void OnEnable()
+        {
+            UnityEditor.Undo.undoRedoPerformed += Apply;
+        }
+
+        private void OnDisable()
+        {
+            UnityEditor.Undo.undoRedoPerformed -= Apply;
+        }
+
+        public void Init(RenderTexture texture)
+        {
+            _target = texture;
+            _stack = new List<RenderTexture>();
+            _counter = CreateInstance<Counter>();
+
+            Record();
+        }
+
+        public void Record()
+        {
+            for (var i = _counter.Count; i < _stack.Count; i++)
+            {
+                if (_stack[i] != null)
+                {
+                    DestroyImmediate(_stack[i]);
+                }
+            }
+            _stack.RemoveRange(_counter.Count, _stack.Count - _counter.Count);
+
+            var copy = new RenderTexture(_target.width, _target.height, 0);
+            Graphics.Blit(_target, copy);
+            RenderTexture.active = null;
+
+            _stack.Add(copy);
+
+            if (_counter.Count > 0)
+            {
+                UnityEditor.Undo.RegisterCompleteObjectUndo(_counter, "Modify Texture");
+            }
+            _counter.Count++;
+        }
+
+        public void Undo()
+        {
+            if (CanUndo)
+            {
+                // Clear Undo as it will be inconsistent with the counter
+                // There might be a better way
+                UnityEditor.Undo.ClearUndo(_counter);
+
+                _counter.Count--;
+
+                Apply();
+            }
+        }
+
+        public void Redo()
+        {
+            if (CanRedo)
+            {
+                // Clear Undo as it will be inconsistent with the counter
+                // There might be a better way
+                UnityEditor.Undo.ClearUndo(_counter);
+
+                _counter.Count++;
+
+                Apply();
+            }
+        }
+
+        private void Apply()
+        {
+            Graphics.Blit(_stack[_counter.Count - 1], _target);
+            RenderTexture.active = null;
+        }
+
+        private void OnDestroy()
+        {
+            if (_stack != null)
+            {
+                foreach (var texture in _stack)
+                {
+                    if (texture != null)
+                    {
+                        DestroyImmediate(texture);
+                    }
+                }
+                _stack = null;
+            }
+            if (_counter != null)
+            {
+                DestroyImmediate(_counter);
+                _counter = null;
+            }
+        }
+    }
+}

--- a/Editor/MaskTextureEditor/TextureUndoStack.cs
+++ b/Editor/MaskTextureEditor/TextureUndoStack.cs
@@ -30,6 +30,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
 
         public bool CanUndo => _counter.Count > 1;
         public bool CanRedo => _counter.Count < _stack.Count;
+        public int State => _stack[_counter.Count - 1].GetInstanceID();
 
         private void Awake()
         {

--- a/Editor/MaskTextureEditor/TextureUndoStack.cs
+++ b/Editor/MaskTextureEditor/TextureUndoStack.cs
@@ -23,14 +23,13 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
         private RenderTexture _target = null;
 
         [SerializeField]
-        private List<RenderTexture> _stack = null;
+        private List<Texture2D> _stack = null;
 
         [SerializeField]
         private Counter _counter = null;
 
         public bool CanUndo => _counter.Count > 1;
         public bool CanRedo => _counter.Count < _stack.Count;
-        public int State => _stack[_counter.Count - 1].GetInstanceID();
 
         private void Awake()
         {
@@ -51,7 +50,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
         public void Init(RenderTexture texture)
         {
             _target = texture;
-            _stack = new List<RenderTexture>();
+            _stack = new List<Texture2D>();
             _counter = CreateInstance<Counter>();
 
             Record();
@@ -68,11 +67,14 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
             }
             _stack.RemoveRange(_counter.Count, _stack.Count - _counter.Count);
 
-            var copy = new RenderTexture(_target.width, _target.height, 0);
-            Graphics.Blit(_target, copy);
+            var texture = new Texture2D(_target.width, _target.height);
+
+            RenderTexture.active = _target;
+            texture.ReadPixels(new Rect(0, 0, texture.width, texture.height), 0, 0);
+            texture.Apply();
             RenderTexture.active = null;
 
-            _stack.Add(copy);
+            _stack.Add(texture);
 
             if (_counter.Count > 0)
             {
@@ -101,6 +103,11 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
 
                 Apply();
             }
+        }
+
+        public Texture2D Peek()
+        {
+            return _stack[_counter.Count - 1];
         }
 
         private void Apply()

--- a/Editor/MaskTextureEditor/TextureUndoStack.cs
+++ b/Editor/MaskTextureEditor/TextureUndoStack.cs
@@ -75,7 +75,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
 
             if (_counter.Count > 0)
             {
-                UnityEditor.Undo.RegisterCompleteObjectUndo(_counter, "Modify Texture");
+                UnityEditor.Undo.RecordObject(_counter, "Modify Texture");
             }
             _counter.Count++;
         }
@@ -84,10 +84,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
         {
             if (CanUndo)
             {
-                // Clear Undo as it will be inconsistent with the counter
-                // There might be a better way
-                UnityEditor.Undo.ClearUndo(_counter);
-
+                UnityEditor.Undo.RecordObject(_counter, "Undo Texture");
                 _counter.Count--;
 
                 Apply();
@@ -98,10 +95,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
         {
             if (CanRedo)
             {
-                // Clear Undo as it will be inconsistent with the counter
-                // There might be a better way
-                UnityEditor.Undo.ClearUndo(_counter);
-
+                UnityEditor.Undo.RecordObject(_counter, "Redo Texture");
                 _counter.Count++;
 
                 Apply();

--- a/Editor/MaskTextureEditor/TextureUndoStack.cs
+++ b/Editor/MaskTextureEditor/TextureUndoStack.cs
@@ -67,7 +67,11 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
             }
             _stack.RemoveRange(_counter.Count, _stack.Count - _counter.Count);
 
-            var texture = new Texture2D(_target.width, _target.height);
+            // Set HideFlags to keep the state when reloading a scene or domain
+            var texture = new Texture2D(_target.width, _target.height)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
 
             RenderTexture.active = _target;
             texture.ReadPixels(new Rect(0, 0, texture.width, texture.height), 0, 0);

--- a/Editor/MaskTextureEditor/TextureUndoStack.cs.meta
+++ b/Editor/MaskTextureEditor/TextureUndoStack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcc4f14e9933d324a988a78d458223d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaskTextureEditor/UvMapDrawer.cs
+++ b/Editor/MaskTextureEditor/UvMapDrawer.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
+{
+    internal class UvMapDrawer : ScriptableObject
+    {
+        [SerializeField]
+        private SkinnedMeshRenderer _renderer = null;
+
+        [SerializeField]
+        private int _subMesh = 0;
+
+        private Mesh _mesh = null;
+        private int _meshDirtyCount = 0;
+        private (Vector3 PointA, Vector3 PointB)[] _lines = null;
+        private Vector3[] _points = null;
+        private int[] _indices = null;
+
+        private void Awake()
+        {
+            // Set HideFlags to keep the state when reloading a scene or domain
+            hideFlags = HideFlags.HideAndDontSave;
+        }
+
+        public void Init(SkinnedMeshRenderer renderer, int subMesh)
+        {
+            _renderer = renderer;
+            _subMesh = subMesh;
+        }
+
+        public void Draw(Rect rect)
+        {
+            if (_mesh != _renderer.sharedMesh ||
+                _meshDirtyCount != EditorUtility.GetDirtyCount(_mesh) ||
+                _lines == null ||
+                _points == null ||
+                _indices == null)
+            {
+                _mesh = _renderer.sharedMesh;
+                _meshDirtyCount = EditorUtility.GetDirtyCount(_mesh);
+                _lines = CollectLines();
+                _points = new Vector3[_lines.Length * 2];
+                _indices = new int[_lines.Length * 2];
+            }
+
+            // Draw the main texture if present
+            if (_subMesh < _renderer.sharedMaterials.Length &&
+                _renderer.sharedMaterials[_subMesh].mainTexture != null)
+            {
+                EditorGUI.DrawTextureTransparent(rect, _renderer.sharedMaterials[_subMesh].mainTexture);
+            }
+
+            // Draw background lines for visibility
+            for (var i = 0; i < _lines.Length; i++)
+            {
+                var indexA = i * 2 + 0;
+                var indexB = i * 2 + 1;
+                var pointA = new Vector2(_lines[i].PointA.x, 1.0f - _lines[i].PointA.y);
+                var pointB = new Vector2(_lines[i].PointB.x, 1.0f - _lines[i].PointB.y);
+                _indices[indexA] = indexA;
+                _indices[indexB] = indexB;
+                _points[indexA] = Rect.NormalizedToPoint(rect, pointA);
+                _points[indexB] = Rect.NormalizedToPoint(rect, pointB);
+            }
+            Handles.color = GUI.color * Color.gray;
+            Handles.DrawLines(_points, _indices);
+
+            // Draw foreground lines with offset
+            for (var i = 0; i < _points.Length; i++)
+            {
+                _points[i] -= (Vector3)Vector2.one;
+            }
+            Handles.color = GUI.color * Color.white;
+            Handles.DrawLines(_points, _indices);
+        }
+
+        private (Vector3 PointA, Vector3 PointB)[] CollectLines()
+        {
+            switch (_mesh.GetTopology(_subMesh))
+            {
+                case MeshTopology.Lines:
+                    return CollectLines(2);
+                case MeshTopology.Triangles:
+                    return CollectLines(3);
+                case MeshTopology.Quads:
+                    return CollectLines(4);
+                default:
+                    return new (Vector3, Vector3)[0];
+            };
+
+            (Vector3 PointA, Vector3 PointB)[] CollectLines(int topology)
+            {
+                var lines = new HashSet<(Vector3, Vector3)>();
+                var points = _mesh.uv;
+                var indices = _mesh.GetIndices(_subMesh);
+                for (var i = 0; i < indices.Length; i++)
+                {
+                    var pointA = points[indices[i / topology * topology + (i + 0) % topology]];
+                    var pointB = points[indices[i / topology * topology + (i + 1) % topology]];
+                    if (!lines.Contains((pointA, pointB)) && !lines.Contains((pointB, pointA)))
+                    {
+                        lines.Add((pointA, pointB));
+                    }
+                }
+                return lines.ToArray();
+            }
+        }
+    }
+}

--- a/Editor/MaskTextureEditor/UvMapDrawer.cs.meta
+++ b/Editor/MaskTextureEditor/UvMapDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c145c85151696e41ac4ceb8ea9563bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaskTextureEditor/Window.cs
+++ b/Editor/MaskTextureEditor/Window.cs
@@ -221,9 +221,17 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
 
             EditorGUILayout.Space();
 
-            _viewScale = EditorGUILayout.Slider(
-                AAOL10N.Tr("MaskTextureEditor:viewScale"),
-                _viewScale, ViewScaleMin, ViewScaleMax);
+            using (var check = new EditorGUI.ChangeCheckScope())
+            {
+                var prev = _viewScale;
+                _viewScale = EditorGUILayout.Slider(
+                    AAOL10N.Tr("MaskTextureEditor:viewScale"),
+                    _viewScale, ViewScaleMin, ViewScaleMax);
+                if (check.changed)
+                {
+                    _viewPosition -= _viewPosition * (1.0f - _viewScale / prev);
+                }
+            }
 
             _viewOpacity = EditorGUILayout.Slider(
                 AAOL10N.Tr("MaskTextureEditor:viewOpacity"),

--- a/Editor/MaskTextureEditor/Window.cs
+++ b/Editor/MaskTextureEditor/Window.cs
@@ -64,7 +64,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
         private string saveChangesMessage = string.Empty;
 #endif
 
-        public static bool IsOpen(SkinnedMeshRenderer renderer, int subMesh, Texture2D texture)
+        public static bool IsOpen(SkinnedMeshRenderer renderer, int subMesh)
         {
             if (!HasOpenInstances<Window>())
             {
@@ -72,7 +72,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
             }
 
             var window = GetWindow<Window>(string.Empty, false);
-            return window._renderer == renderer && window._subMesh == subMesh && window._texture == texture;
+            return window._renderer == renderer && window._subMesh == subMesh;
         }
 
         public void Open(SkinnedMeshRenderer renderer, int subMesh, Texture2D texture)

--- a/Editor/MaskTextureEditor/Window.cs
+++ b/Editor/MaskTextureEditor/Window.cs
@@ -1,0 +1,399 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
+{
+    internal class Window : EditorWindow
+    {
+        private static class Style
+        {
+            public readonly static GUIStyle Toolbar = new GUIStyle("Toolbar")
+            {
+                fixedHeight = 0.0f,
+            };
+            public readonly static GUIStyle Button = new GUIStyle("button")
+            {
+                fixedHeight = 24.0f,
+            };
+        }
+
+        private const float ViewScaleMin = 0.1f;
+        private const float ViewScaleMax = 10.0f;
+        private const float ViewScaleFactor = 0.1f;
+        private const float BrushSizeMin = 10.0f;
+        private const float BrushSizeMax = 1000.0f;
+        private const float BrushSizeFactor = 0.1f;
+
+        [SerializeField]
+        private SkinnedMeshRenderer _renderer = null;
+
+        [SerializeField]
+        private int _subMesh = 0;
+
+        [SerializeField]
+        private Texture2D _texture = null;
+
+        [SerializeField]
+        private Vector2 _viewPosition = Vector2.zero;
+
+        [SerializeField]
+        private float _viewScale = 1.0f;
+
+        [SerializeField]
+        private float _viewOpacity = 0.5f;
+
+        [SerializeField]
+        private bool _requestResetView = true;
+
+        [SerializeField]
+        private UvMapDrawer _uvMapDrawer = null;
+
+        [SerializeField]
+        private TexturePainter _texturePainter = null;
+
+        [SerializeField]
+        private TextureUndoStack _textureUndoStack = null;
+
+        public static bool IsOpen(SkinnedMeshRenderer renderer, int subMesh, Texture2D texture)
+        {
+            if (!HasOpenInstances<Window>())
+            {
+                return false;
+            }
+
+            var window = GetWindow<Window>(string.Empty, false);
+            return window._renderer == renderer && window._subMesh == subMesh && window._texture == texture;
+        }
+
+        public void Open(SkinnedMeshRenderer renderer, int subMesh, Texture2D texture)
+        {
+            _renderer = renderer;
+            _subMesh = subMesh;
+            _texture = texture;
+
+            _uvMapDrawer = CreateInstance<UvMapDrawer>();
+            _uvMapDrawer.Init(renderer, subMesh);
+
+            _texturePainter = CreateInstance<TexturePainter>();
+            _texturePainter.Init(texture);
+
+            _textureUndoStack = CreateInstance<TextureUndoStack>();
+            _textureUndoStack.Init(_texturePainter.Texture);
+        }
+
+        private void OnGUI()
+        {
+            wantsMouseMove = true;
+            titleContent.text = AAOL10N.Tr("MaskTextureEditor:title");
+
+            if (_renderer == null ||
+                _renderer.sharedMesh == null ||
+                _subMesh >= _renderer.sharedMesh.subMeshCount ||
+                _texture == null)
+            {
+                return;
+            }
+
+            using (new EditorGUILayout.VerticalScope(Style.Toolbar))
+            {
+                DrawToolbar();
+            }
+
+            var scrollRect = GUILayoutUtility.GetRect(
+                0.0f,
+                0.0f,
+                GUILayout.ExpandWidth(true),
+                GUILayout.ExpandHeight(true));
+            var viewportRect = new Rect(
+                scrollRect.position.x,
+                scrollRect.position.y,
+                scrollRect.size.x - GUI.skin.verticalScrollbar.fixedWidth,
+                scrollRect.size.y - GUI.skin.horizontalScrollbar.fixedHeight);
+
+            // Add margins of half of the viewport on each side to make it easier to edit the edges of the texture
+            var viewRect = new Rect(Vector2.zero, _texturePainter.TextureSize * _viewScale + viewportRect.size);
+            var contentRect = new Rect(viewportRect.size * 0.5f, _texturePainter.TextureSize * _viewScale);
+
+            using (var scroll = new GUI.ScrollViewScope(scrollRect, _viewPosition, viewRect, true, true)
+            {
+                handleScrollWheel = false,
+            })
+            {
+                _viewPosition = scroll.scrollPosition;
+
+                DrawContents(contentRect);
+            }
+
+            HandleEvents(viewportRect);
+        }
+
+        private void DrawToolbar()
+        {
+            AAOL10N.DrawLanguagePicker();
+
+            using (new EditorGUI.DisabledScope(true))
+            {
+                EditorGUILayout.ObjectField(
+                    AAOL10N.Tr("MaskTextureEditor:renderer"),
+                    _renderer, typeof(SkinnedMeshRenderer), true);
+
+                EditorGUILayout.LabelField(
+                    AAOL10N.Tr("MaskTextureEditor:subMesh"),
+                    string.Format(AAOL10N.Tr("MaskTextureEditor:subMeshIndex"), _subMesh));
+
+                EditorGUILayout.ObjectField(
+                    AAOL10N.Tr("MaskTextureEditor:texture"),
+                    _texture, typeof(Texture2D), true, GUILayout.Height(EditorGUIUtility.singleLineHeight));
+            }
+
+            if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:save"), Style.Button))
+            {
+                Save();
+            }
+
+            EditorGUILayout.Space();
+
+            _viewScale = EditorGUILayout.Slider(
+                AAOL10N.Tr("MaskTextureEditor:viewScale"),
+                _viewScale, ViewScaleMin, ViewScaleMax);
+
+            _viewOpacity = EditorGUILayout.Slider(
+                AAOL10N.Tr("MaskTextureEditor:viewOpacity"),
+                _viewOpacity, 0.0f, 1.0f);
+
+            if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:resetView"), Style.Button))
+            {
+                _requestResetView = true;
+            }
+
+            EditorGUILayout.Space();
+
+            _texturePainter.BrushSize = EditorGUILayout.Slider(
+                AAOL10N.Tr("MaskTextureEditor:brushSize"),
+                _texturePainter.BrushSize, BrushSizeMin, BrushSizeMax);
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.PrefixLabel(AAOL10N.Tr("MaskTextureEditor:brushColor"));
+
+                var colors = new[]
+                {
+                    Color.black,
+                    Color.white,
+                };
+                var texts = new[]
+                {
+                    AAOL10N.Tr("MaskTextureEditor:black"),
+                    AAOL10N.Tr("MaskTextureEditor:white"),
+                };
+                var index = Array.IndexOf(colors, _texturePainter.BrushColor);
+                _texturePainter.BrushColor = colors[GUILayout.Toolbar(index, texts)];
+            }
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                using (new EditorGUI.DisabledScope(!_textureUndoStack.CanUndo))
+                {
+                    if (GUILayout.Button(EditorGUIUtility.TrIconContent("tab_prev"),
+                        Style.Button, GUILayout.ExpandWidth(false)))
+                    {
+                        _textureUndoStack.Undo();
+                    }
+                }
+                using (new EditorGUI.DisabledScope(!_textureUndoStack.CanRedo))
+                {
+                    if (GUILayout.Button(EditorGUIUtility.TrIconContent("tab_next"),
+                        Style.Button, GUILayout.ExpandWidth(false)))
+                    {
+                        _textureUndoStack.Redo();
+                    }
+                }
+                if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:fillBlack"), Style.Button))
+                {
+                    _texturePainter.Fill(Color.black);
+                    _textureUndoStack.Record();
+                }
+                if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:fillWhite"), Style.Button))
+                {
+                    _texturePainter.Fill(Color.white);
+                    _textureUndoStack.Record();
+                }
+                if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:inverse"), Style.Button))
+                {
+                    _texturePainter.Inverse();
+                    _textureUndoStack.Record();
+                }
+            }
+
+            EditorGUILayout.Space();
+        }
+
+        private void DrawContents(Rect rect)
+        {
+            GUI.color = new Color(1.0f, 1.0f, 1.0f, 1.0f);
+            _uvMapDrawer.Draw(rect);
+
+            GUI.color = new Color(1.0f, 1.0f, 1.0f, _viewOpacity);
+            _texturePainter.Draw(rect);
+        }
+
+        private void HandleEvents(Rect rect)
+        {
+            var control = GUIUtility.GetControlID(FocusType.Passive);
+            var type = Event.current.GetTypeForControl(control);
+            switch (type)
+            {
+                case EventType.Repaint:
+                {
+                    if (_requestResetView)
+                    {
+                        // Fit the view to the window
+                        _viewScale = Mathf.Min(
+                            rect.size.x / _texturePainter.TextureSize.x,
+                            rect.size.y / _texturePainter.TextureSize.y);
+                        _viewScale = Mathf.Clamp(_viewScale, ViewScaleMin, ViewScaleMax);
+                        _viewPosition = _texturePainter.TextureSize * _viewScale * 0.5f;
+                        _requestResetView = false;
+                        Repaint();
+                    }
+                    break;
+                }
+                case EventType.MouseMove when rect.Contains(Event.current.mousePosition):
+                {
+                    Repaint();
+                    break;
+                }
+                case EventType.MouseDown when rect.Contains(Event.current.mousePosition):
+                {
+                    // Set HotControl to continue dragging outside of the window
+                    GUIUtility.hotControl = control;
+
+                    if (Event.current.button == 0)
+                    {
+                        // Paint the texture
+                        var position = Event.current.mousePosition - rect.center + _viewPosition;
+                        _texturePainter.Paint(position / _viewScale, position / _viewScale);
+                        Repaint();
+                    }
+                    break;
+                }
+                case EventType.MouseUp when GUIUtility.hotControl == control:
+                {
+                    // Unset HotControl to allow other controls to respond
+                    GUIUtility.hotControl = 0;
+
+                    if (Event.current.button == 0)
+                    {
+                        _textureUndoStack.Record();
+                    }
+                    break;
+                }
+                case EventType.MouseDrag when GUIUtility.hotControl == control:
+                {
+                    var delta = Event.current.delta;
+                    if (Event.current.button == 0)
+                    {
+                        // Paint the texture
+                        var position = Event.current.mousePosition - rect.center + _viewPosition;
+                        _texturePainter.Paint((position - delta) / _viewScale, position / _viewScale);
+                        Repaint();
+                    }
+                    else
+                    {
+                        // Move the view
+                        _viewPosition -= delta;
+                        Repaint();
+                    }
+                    break;
+                }
+                case EventType.ScrollWheel when rect.Contains(Event.current.mousePosition):
+                {
+                    var delta = Event.current.delta.x + Event.current.delta.y;
+                    if (Event.current.shift)
+                    {
+                        // Adjust the brush size
+                        _texturePainter.BrushSize *= 1.0f - delta * BrushSizeFactor;
+                        _texturePainter.BrushSize = Mathf.Clamp(_texturePainter.BrushSize, BrushSizeMin, BrushSizeMax);
+                        Repaint();
+                    }
+                    else
+                    {
+                        // Scale the view around the mouse position
+                        var prev = _viewScale;
+                        _viewScale *= 1.0f - delta * ViewScaleFactor;
+                        _viewScale = Mathf.Clamp(_viewScale, ViewScaleMin, ViewScaleMax);
+                        var position = Event.current.mousePosition - rect.center + _viewPosition;
+                        _viewPosition -= position * (1.0f - _viewScale / prev);
+                        Repaint();
+                    }
+                    break;
+                }
+                case EventType.ValidateCommand:
+                {
+                    Repaint();
+                    break;
+                }
+            }
+
+            // Ensure non-negative position to avoid scrollbars flickering
+            _viewPosition = Vector2.Max(_viewPosition, Vector2.zero);
+        }
+
+        private void Save()
+        {
+            var path = AssetDatabase.GetAssetPath(_texture);
+
+            var texture = new Texture2D(0, 0);
+            _texturePainter.Save(texture);
+
+            try
+            {
+                File.WriteAllBytes(path, texture.EncodeToPNG());
+
+                AssetDatabase.ImportAsset(path);
+
+                var importer = AssetImporter.GetAtPath(path) as TextureImporter;
+                importer.isReadable = true;
+                importer.SaveAndReimport();
+
+                // Tap the renderer to update the mesh preview
+                // There might be a better way
+                EditorUtility.SetDirty(_renderer);
+            }
+            catch (Exception e)
+            {
+                EditorUtility.DisplayDialog(
+                    AAOL10N.Tr("MaskTextureEditor:errorTitle"),
+                    AAOL10N.Tr("MaskTextureEditor:errorMessageSaveFailed"),
+                    AAOL10N.Tr("MaskTextureEditor:errorButton"));
+
+                Debug.LogError(e);
+            }
+            finally
+            {
+                DestroyImmediate(texture);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_uvMapDrawer != null)
+            {
+                DestroyImmediate(_uvMapDrawer);
+                _uvMapDrawer = null;
+            }
+            if (_texturePainter != null)
+            {
+                DestroyImmediate(_texturePainter);
+                _texturePainter = null;
+            }
+            if (_textureUndoStack != null)
+            {
+                DestroyImmediate(_textureUndoStack);
+                _textureUndoStack = null;
+            }
+        }
+    }
+}

--- a/Editor/MaskTextureEditor/Window.cs
+++ b/Editor/MaskTextureEditor/Window.cs
@@ -7,7 +7,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
 {
     internal class Window : EditorWindow
     {
-        private static class Style
+        private static class Styles
         {
             public readonly static GUIStyle Toolbar = new GUIStyle("Toolbar")
             {
@@ -17,6 +17,16 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
             {
                 fixedHeight = 24.0f,
             };
+        }
+
+        private static class Events
+        {
+            public static bool Paint => Event.current.button == 0
+                && !Event.current.alt
+                && !Event.current.shift
+                && !Event.current.control
+                && !Event.current.command;
+            public static bool BrushSize => Event.current.shift;
         }
 
         private const float ViewScaleMin = 0.1f;
@@ -152,7 +162,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 return;
             }
 
-            using (new EditorGUILayout.VerticalScope(Style.Toolbar))
+            using (new EditorGUILayout.VerticalScope(Styles.Toolbar))
             {
                 DrawToolbar();
             }
@@ -204,7 +214,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                     _texture, typeof(Texture2D), true, GUILayout.Height(EditorGUIUtility.singleLineHeight));
             }
 
-            if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:save"), Style.Button))
+            if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:save"), Styles.Button))
             {
                 SaveChanges();
             }
@@ -219,7 +229,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 AAOL10N.Tr("MaskTextureEditor:viewOpacity"),
                 _viewOpacity, 0.0f, 1.0f);
 
-            if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:resetView"), Style.Button))
+            if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:resetView"), Styles.Button))
             {
                 _requestResetView = true;
             }
@@ -253,7 +263,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 using (new EditorGUI.DisabledScope(!_textureUndoStack.CanUndo))
                 {
                     if (GUILayout.Button(EditorGUIUtility.TrIconContent("tab_prev"),
-                        Style.Button, GUILayout.ExpandWidth(false)))
+                        Styles.Button, GUILayout.ExpandWidth(false)))
                     {
                         _textureUndoStack.Undo();
                     }
@@ -261,22 +271,22 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 using (new EditorGUI.DisabledScope(!_textureUndoStack.CanRedo))
                 {
                     if (GUILayout.Button(EditorGUIUtility.TrIconContent("tab_next"),
-                        Style.Button, GUILayout.ExpandWidth(false)))
+                        Styles.Button, GUILayout.ExpandWidth(false)))
                     {
                         _textureUndoStack.Redo();
                     }
                 }
-                if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:fillBlack"), Style.Button))
+                if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:fillBlack"), Styles.Button))
                 {
                     _texturePainter.Fill(Color.black);
                     _textureUndoStack.Record();
                 }
-                if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:fillWhite"), Style.Button))
+                if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:fillWhite"), Styles.Button))
                 {
                     _texturePainter.Fill(Color.white);
                     _textureUndoStack.Record();
                 }
-                if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:inverse"), Style.Button))
+                if (GUILayout.Button(AAOL10N.Tr("MaskTextureEditor:inverse"), Styles.Button))
                 {
                     _texturePainter.Inverse();
                     _textureUndoStack.Record();
@@ -326,7 +336,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                     // Set HotControl to continue dragging outside of the window
                     GUIUtility.hotControl = control;
 
-                    if (Event.current.button == 0)
+                    if (Events.Paint)
                     {
                         // Paint the texture
                         var position = Event.current.mousePosition - rect.center + _viewPosition;
@@ -340,7 +350,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                     // Unset HotControl to allow other controls to respond
                     GUIUtility.hotControl = 0;
 
-                    if (Event.current.button == 0)
+                    if (Events.Paint)
                     {
                         _textureUndoStack.Record();
                         Repaint();
@@ -350,7 +360,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 case EventType.MouseDrag when GUIUtility.hotControl == control:
                 {
                     var delta = Event.current.delta;
-                    if (Event.current.button == 0)
+                    if (Events.Paint)
                     {
                         // Paint the texture
                         var position = Event.current.mousePosition - rect.center + _viewPosition;
@@ -368,7 +378,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 case EventType.ScrollWheel when rect.Contains(Event.current.mousePosition):
                 {
                     var delta = Event.current.delta.x + Event.current.delta.y;
-                    if (Event.current.shift)
+                    if (Events.BrushSize)
                     {
                         // Adjust the brush size
                         _texturePainter.BrushSize *= 1.0f - delta * BrushSizeFactor;

--- a/Editor/MaskTextureEditor/Window.cs
+++ b/Editor/MaskTextureEditor/Window.cs
@@ -367,7 +367,7 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
                 EditorUtility.DisplayDialog(
                     AAOL10N.Tr("MaskTextureEditor:errorTitle"),
                     AAOL10N.Tr("MaskTextureEditor:errorMessageSaveFailed"),
-                    AAOL10N.Tr("MaskTextureEditor:errorButton"));
+                    "OK");
 
                 Debug.LogError(e);
             }

--- a/Editor/MaskTextureEditor/Window.cs
+++ b/Editor/MaskTextureEditor/Window.cs
@@ -74,6 +74,19 @@ namespace Anatawa12.AvatarOptimizer.MaskTextureEditor
         private string saveChangesMessage = string.Empty;
 #endif
 
+        public static Window Instance
+        {
+            get
+            {
+                if (!HasOpenInstances<Window>())
+                {
+                    return null;
+                }
+
+                return GetWindow<Window>(string.Empty, false);
+            }
+        }
+
         public Texture2D PreviewTexture => _textureUndoStack.Peek();
 
         public static bool IsOpen(SkinnedMeshRenderer renderer)

--- a/Editor/MaskTextureEditor/Window.cs.meta
+++ b/Editor/MaskTextureEditor/Window.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef74988983a72b64690935d4c44e7e54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Localization/en-us.po
+++ b/Localization/en-us.po
@@ -506,6 +506,18 @@ msgstr "Fill White"
 msgid "MaskTextureEditor:inverse"
 msgstr "Inverse Color"
 
+msgid "MaskTextureEditor:saveChangesMessage"
+msgstr "There are unsaved changes. Would you like to save?"
+
+msgid "MaskTextureEditor:saveChangesButtonSave"
+msgstr "Save"
+
+msgid "MaskTextureEditor:saveChangesButtonDiscard"
+msgstr "Discard"
+
+msgid "MaskTextureEditor:saveChangesButtonCancel"
+msgstr "Cancel"
+
 msgid "MaskTextureEditor:errorTitle"
 msgstr "Error"
 

--- a/Localization/en-us.po
+++ b/Localization/en-us.po
@@ -459,7 +459,7 @@ msgid "MaskTextureEditor:edit"
 msgstr "Edit"
 
 msgid "MaskTextureEditor:title"
-msgstr "MaskTextureEditor"
+msgstr "AAO MaskTextureEditor"
 
 msgid "MaskTextureEditor:renderer"
 msgstr "Skinned Mesh Renderer"
@@ -504,16 +504,16 @@ msgid "MaskTextureEditor:fillWhite"
 msgstr "Fill White"
 
 msgid "MaskTextureEditor:inverse"
-msgstr "Inverse"
+msgstr "Inverse Color"
 
 msgid "MaskTextureEditor:errorTitle"
 msgstr "Error"
 
 msgid "MaskTextureEditor:errorMessageCreateFailed"
-msgstr "Failed to create the texture"
+msgstr "Failed to create the texture."
 
 msgid "MaskTextureEditor:errorMessageSaveFailed"
-msgstr "Failed to save the texture"
+msgstr "Failed to save the texture."
 
 msgid "MaskTextureEditor:errorButton"
 msgstr "OK"

--- a/Localization/en-us.po
+++ b/Localization/en-us.po
@@ -450,6 +450,76 @@ msgstr "No Mesh is specified to the Skinned Mesh Renderer."
 
 # endregion
 
+# region MaskTextureEditor
+
+msgid "MaskTextureEditor:create"
+msgstr "Create"
+
+msgid "MaskTextureEditor:edit"
+msgstr "Edit"
+
+msgid "MaskTextureEditor:title"
+msgstr "MaskTextureEditor"
+
+msgid "MaskTextureEditor:renderer"
+msgstr "Skinned Mesh Renderer"
+
+msgid "MaskTextureEditor:subMesh"
+msgstr "Material Slot"
+
+msgid "MaskTextureEditor:subMeshIndex"
+msgstr "{0}"
+
+msgid "MaskTextureEditor:texture"
+msgstr "Mask Texture"
+
+msgid "MaskTextureEditor:save"
+msgstr "Save"
+
+msgid "MaskTextureEditor:viewScale"
+msgstr "View Scale (Scroll)"
+
+msgid "MaskTextureEditor:viewOpacity"
+msgstr "View Opacity"
+
+msgid "MaskTextureEditor:resetView"
+msgstr "Fit the view to the window"
+
+msgid "MaskTextureEditor:brushSize"
+msgstr "Brush Size (Shift + Scroll)"
+
+msgid "MaskTextureEditor:brushColor"
+msgstr "Brush Color"
+
+msgid "MaskTextureEditor:black"
+msgstr "Black"
+
+msgid "MaskTextureEditor:white"
+msgstr "White"
+
+msgid "MaskTextureEditor:fillBlack"
+msgstr "Fill Black"
+
+msgid "MaskTextureEditor:fillWhite"
+msgstr "Fill White"
+
+msgid "MaskTextureEditor:inverse"
+msgstr "Inverse"
+
+msgid "MaskTextureEditor:errorTitle"
+msgstr "Error"
+
+msgid "MaskTextureEditor:errorMessageCreateFailed"
+msgstr "Failed to create the texture"
+
+msgid "MaskTextureEditor:errorMessageSaveFailed"
+msgstr "Failed to save the texture"
+
+msgid "MaskTextureEditor:errorButton"
+msgstr "OK"
+
+# endregion
+
 # region AvatarGlobalComponent
 
 msgid "AvatarGlobalComponent:NotOnAvatarRoot"

--- a/Localization/en-us.po
+++ b/Localization/en-us.po
@@ -510,13 +510,10 @@ msgid "MaskTextureEditor:errorTitle"
 msgstr "Error"
 
 msgid "MaskTextureEditor:errorMessageCreateFailed"
-msgstr "Failed to create the texture."
+msgstr "Failed to create the texture. Refer to the log for details."
 
 msgid "MaskTextureEditor:errorMessageSaveFailed"
-msgstr "Failed to save the texture."
-
-msgid "MaskTextureEditor:errorButton"
-msgstr "OK"
+msgstr "Failed to save the texture. Refer to the log for details."
 
 # endregion
 

--- a/Localization/ja-jp.po
+++ b/Localization/ja-jp.po
@@ -360,6 +360,76 @@ msgstr "Skinned Mesh RendererにMeshが設定されていません。"
 
 # endregion
 
+# region MaskTextureEditor
+
+msgid "MaskTextureEditor:create"
+msgstr "作成"
+
+msgid "MaskTextureEditor:edit"
+msgstr "編集"
+
+msgid "MaskTextureEditor:title"
+msgstr "マスクテクスチャエディター"
+
+msgid "MaskTextureEditor:renderer"
+msgstr "スキンメッシュレンダラー"
+
+msgid "MaskTextureEditor:subMesh"
+msgstr "マテリアルスロット"
+
+msgid "MaskTextureEditor:subMeshIndex"
+msgstr "{0}番"
+
+msgid "MaskTextureEditor:texture"
+msgstr "マスクテクスチャ"
+
+msgid "MaskTextureEditor:save"
+msgstr "保存する"
+
+msgid "MaskTextureEditor:viewScale"
+msgstr "表示倍率 (Scroll)"
+
+msgid "MaskTextureEditor:viewOpacity"
+msgstr "表示透明度"
+
+msgid "MaskTextureEditor:resetView"
+msgstr "表示をウィンドウに合わせる"
+
+msgid "MaskTextureEditor:brushSize"
+msgstr "ブラシサイズ (Shift + Scroll)"
+
+msgid "MaskTextureEditor:brushColor"
+msgstr "ブラシカラー"
+
+msgid "MaskTextureEditor:black"
+msgstr "黒"
+
+msgid "MaskTextureEditor:white"
+msgstr "白"
+
+msgid "MaskTextureEditor:fillBlack"
+msgstr "黒で塗りつぶす"
+
+msgid "MaskTextureEditor:fillWhite"
+msgstr "白で塗りつぶす"
+
+msgid "MaskTextureEditor:inverse"
+msgstr "反転する"
+
+msgid "MaskTextureEditor:errorTitle"
+msgstr "エラー"
+
+msgid "MaskTextureEditor:errorMessageCreateFailed"
+msgstr "テクスチャの作成に失敗しました"
+
+msgid "MaskTextureEditor:errorMessageSaveFailed"
+msgstr "テクスチャの保存に失敗しました"
+
+msgid "MaskTextureEditor:errorButton"
+msgstr "OK"
+
+# endregion
+
 # region AvatarGlobalComponent
 
 msgid "AvatarGlobalComponent:NotOnAvatarRoot"

--- a/Localization/ja-jp.po
+++ b/Localization/ja-jp.po
@@ -369,7 +369,7 @@ msgid "MaskTextureEditor:edit"
 msgstr "編集"
 
 msgid "MaskTextureEditor:title"
-msgstr "マスクテクスチャエディター"
+msgstr "AAO マスクテクスチャエディター"
 
 msgid "MaskTextureEditor:renderer"
 msgstr "スキンメッシュレンダラー"
@@ -414,16 +414,16 @@ msgid "MaskTextureEditor:fillWhite"
 msgstr "白で塗りつぶす"
 
 msgid "MaskTextureEditor:inverse"
-msgstr "反転する"
+msgstr "色を反転させる"
 
 msgid "MaskTextureEditor:errorTitle"
 msgstr "エラー"
 
 msgid "MaskTextureEditor:errorMessageCreateFailed"
-msgstr "テクスチャの作成に失敗しました"
+msgstr "テクスチャの作成に失敗しました。"
 
 msgid "MaskTextureEditor:errorMessageSaveFailed"
-msgstr "テクスチャの保存に失敗しました"
+msgstr "テクスチャの保存に失敗しました。"
 
 msgid "MaskTextureEditor:errorButton"
 msgstr "OK"

--- a/Localization/ja-jp.po
+++ b/Localization/ja-jp.po
@@ -416,6 +416,18 @@ msgstr "白で塗りつぶす"
 msgid "MaskTextureEditor:inverse"
 msgstr "色を反転させる"
 
+msgid "MaskTextureEditor:saveChangesMessage"
+msgstr "保存されていない変更があります。保存しますか？"
+
+msgid "MaskTextureEditor:saveChangesButtonSave"
+msgstr "保存"
+
+msgid "MaskTextureEditor:saveChangesButtonDiscard"
+msgstr "破棄"
+
+msgid "MaskTextureEditor:saveChangesButtonCancel"
+msgstr "キャンセル"
+
 msgid "MaskTextureEditor:errorTitle"
 msgstr "エラー"
 

--- a/Localization/ja-jp.po
+++ b/Localization/ja-jp.po
@@ -420,13 +420,10 @@ msgid "MaskTextureEditor:errorTitle"
 msgstr "エラー"
 
 msgid "MaskTextureEditor:errorMessageCreateFailed"
-msgstr "テクスチャの作成に失敗しました。"
+msgstr "テクスチャの作成に失敗しました。詳細はログを参照してください。"
 
 msgid "MaskTextureEditor:errorMessageSaveFailed"
-msgstr "テクスチャの保存に失敗しました。"
-
-msgid "MaskTextureEditor:errorButton"
-msgstr "OK"
+msgstr "テクスチャの保存に失敗しました。詳細はログを参照してください。"
 
 # endregion
 


### PR DESCRIPTION
Resolves #1000 です。

Remove Mesh By Mask のマスクテクスチャのフィールドが None の場合は作成ボタンを表示し、そうでない場合は編集ボタンを表示します。
![1000-0](https://github.com/anatawa12/AvatarOptimizer/assets/4340778/aed3d390-7882-451a-a19d-3baa7548697c)
![1000-1](https://github.com/anatawa12/AvatarOptimizer/assets/4340778/2e3915e1-1ab4-49ab-83c7-3146a7c12861)

作成ボタンを押すとファイル保存ダイアログが開き、編集ボタンを押すとマスクテクスチャエディターが開きます。
マスクテクスチャエディターには必須かなと思う機能を実装しています。
![1000-2](https://github.com/anatawa12/AvatarOptimizer/assets/4340778/e43ef713-a0a9-4155-aa05-0a414c575236)
