### PR TITLE
fix: mesh preview causes empty mesh if reload scene on enter play mode is disabled

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Mesh preview may cause empty mesh on enter play mode if reload scene is disabled [`#1064`](https://github.com/anatawa12/AvatarOptimizer/pull/1064)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Mesh preview may cause empty mesh on enter play mode if reload scene is disabled [`#1064`](https://github.com/anatawa12/AvatarOptimizer/pull/1064)
 
 ### Security
 

--- a/Editor/EditModePreview/MeshPreviewController.cs
+++ b/Editor/EditModePreview/MeshPreviewController.cs
@@ -62,7 +62,7 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
                     _previewController = new RemoveMeshPreviewController(targetRenderer, originalMesh, previewMesh);
 
                 if (_previewController == null || targetRenderer == null || ActiveEditor() != targetRenderer.gameObject 
-                    || EditorApplication.isPlaying || !AnimationMode.InAnimationMode(DriverCached))
+                    || EditorApplication.isPlayingOrWillChangePlaymode || !AnimationMode.InAnimationMode(DriverCached))
                 {
                     StopPreview();
                     return;
@@ -96,31 +96,7 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
                 case PlayModeStateChange.ExitingEditMode:
                     // stop previewing when exit edit mode
                     Debug.Log("stop previewing when exit edit mode");
-                    
-                    // Exiting Animation mode on entering play mode may leave the mesh none so we just rollback mesh to original one
-                    if (AnimationMode.InAnimationMode(DriverCached) && _previewController != null)
-                    {
-                        try
-                        {
-                            AnimationMode.BeginSampling();
-
-                            AnimationMode.AddPropertyModification(
-                                EditorCurveBinding.PPtrCurve("", typeof(SkinnedMeshRenderer), "m_Mesh"),
-                                new PropertyModification
-                                {
-                                    target = _previewController.TargetRenderer,
-                                    propertyPath = "m_Mesh",
-                                    objectReference = _previewController.OriginalMesh,
-                                }, 
-                                true);
-
-                            _previewController.TargetRenderer.sharedMesh = _previewController.OriginalMesh;
-                        }
-                        finally
-                        {
-                            AnimationMode.EndSampling();   
-                        }
-                    }
+                    StopPreview();
                     break;
                 case PlayModeStateChange.EnteredPlayMode:
                     break;
@@ -146,7 +122,7 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
 
         private PreviewState StateForImpl([CanBeNull] Component component)
         {
-            if (EditorApplication.isPlaying) return PreviewState.InPlayMode;
+            if (EditorApplication.isPlayingOrWillChangePlaymode) return PreviewState.InPlayMode;
 
             var gameObject = component ? component.gameObject : null;
 


### PR DESCRIPTION
Fixes #1049 です。

`MeshInfo2.WriteToSkinnedMeshRenderer()` で正しく `AAOGeneratedMeshXXXX` が割り当てられた後、
`MeshPreviewController.Update()` から `StopPreview()` が呼ばれて元アセットのメッシュに戻っているようでした。

本 pullreq ではここで `StopPreview()` を呼ぶようにしていますが、そうしないようコメントにあるのは Play ボタンを押してから Reload Domain/Scene 中にメッシュが完全に消えて見えることへの対策でしょうか？
https://github.com/anatawa12/AvatarOptimizer/blob/06c334e01875be25712a78dac8660336a793e2a5/Editor/EditModePreview/MeshPreviewController.cs#L96-L123

もしそうでしたら、ここで `StopPreview()` を呼ぶだけだと直後の `Update()` で再び `StartPrevew()` されてしまうことが原因なので、`EditorApplication.isPlaying` の判定を `EditorApplication.isPlayingOrWillChangePlaymode` に変更している本 pullreq の対応であれば大丈夫かなと思います。(Reload Domain/Scene がオンの場合 Reload Domain/Scene 中はプレビューが終了した状態が見えます)

そうではない別の事象への対策ということであれば、大丈夫ではないかもしれません。