### PR TITLE
fix: Dependencies of FinalIK Components referenced by IKExecutionOrder

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- FinalIK Gimmicks with IKExecutionOrder is broken `#1153`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - VRCConstraints with Target might be removed unexpectedly `#1150`
+- FinalIK Gimmicks with IKExecutionOrder is broken `#1153`
 
 ### Security
 

--- a/Editor/APIInternal/ComponentInfos.FinalIK.cs
+++ b/Editor/APIInternal/ComponentInfos.FinalIK.cs
@@ -37,10 +37,11 @@ namespace Anatawa12.AvatarOptimizer.APIInternal.Externals
         protected override void CollectDependency(Component component, ComponentDependencyCollector collector)
         {
             collector.MarkEntrypoint();
+            collector.MarkBehaviour();
             using (var serialized = new SerializedObject(component))
                 foreach (var property in serialized.ObjectReferenceProperties())
                     if (property.objectReferenceValue is Component c)
-                        collector.AddDependency(c);
+                        collector.AddDependency(c).EvenIfDependantDisabled();
         }
 
         protected override void CollectMutations(Component component, ComponentMutationsCollector collector)


### PR DESCRIPTION
Fixes #1152 