### PR TITLE
chore: skipEnablementMismatchedRenderers is now disabled by default

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog].
   - Combined with Entry / Exit to 1D BlendTree optimization, which is implemented in previous release, your AnyState layer may be optimized to 1D BlendTree.
 
 ### Changed
+- Skip Enablement Mismatched Renderers is now disabled by default `#1169`
+  - You still can enable it in the Inspector.
+  - This change does not affect the behavior of previously added components.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog].
   - Combined with Entry / Exit to 1D BlendTree optimization, which is implemented in previous release, your AnyState layer may be optimized to 1D BlendTree.
 
 ### Changed
+- Skip Enablement Mismatched Renderers is now disabled by default `#1169`
+  - You still can enable it in the Inspector.
+  - This change does not affect the behavior of previously added components.
 
 ### Deprecated
 

--- a/Runtime/MergeSkinnedMesh.cs
+++ b/Runtime/MergeSkinnedMesh.cs
@@ -37,11 +37,6 @@ namespace Anatawa12.AvatarOptimizer
 
         APIChecker _checker;
 
-        private void Reset()
-        {
-            skipEnablementMismatchedRenderers = true;
-        }
-
         internal MergeSkinnedMesh()
         {
             renderersSet = new PrefabSafeSet.PrefabSafeSet<SkinnedMeshRenderer>(this);
@@ -59,6 +54,10 @@ namespace Anatawa12.AvatarOptimizer
         /// <param name="version">
         /// The default configuration version.
         /// Since 1.7.0, version 1 is supported.
+        ///
+        /// Since 1.8.0, version 2 is supported.
+        /// Changes:
+        /// - Default value for skipEnablementMismatchedRenderers is changed. Before 1.8.0: true, 1.8.0 and later: false
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">Unsupported configuration version</exception>
         [PublicAPI]
@@ -67,6 +66,9 @@ namespace Anatawa12.AvatarOptimizer
             switch (version)
             {
                 case 1:
+                    skipEnablementMismatchedRenderers = true;
+                    goto case 2;
+                case 2:
                     // nothing to do
                     break; 
                 default:


### PR DESCRIPTION
Fixes #1070 
