### PR TITLE
fix: SupportsMultiple components with only one on a renderer are ignored

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog].
 ### Fixed
 - Typo in menu for creating Asset Description `#1213`
 - Optimize Texture broken with Crunch Compression `#1215`
+- `SupportsMultiple()` render filters ignore renderers with only one component attached `#1218`
 
 ### Security
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog].
 ### Changed
 - Improved Prefab Safe Set, which are used in MergePhysBone, MergeSkinnedMesh, FreezeBlendShape and more components `#1212`
   - This should improve compatibility with replacing base prefab, which is added in Unity 2022.
-- Allow multiple component for Remove Mesh components with API `#1216`
+- Allow multiple component for Remove Mesh components with API `#1216` `#1218`
   - This allows non-destructive tools to add Remove Mesh components even if Remove Mesh component are added before.
 
 ### Deprecated
@@ -23,7 +23,6 @@ The format is based on [Keep a Changelog].
 ### Fixed
 - Typo in menu for creating Asset Description `#1213`
 - Optimize Texture broken with Crunch Compression `#1215`
-- `SupportsMultiple()` render filters ignore renderers with only one component attached `#1218`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,12 @@ The format is based on [Keep a Changelog].
 - Use UInt16 index buffer if possible even when total vertex count is more than 2^16 `#1178`
   - With baseVertex in index buffer, we can use UInt16 index buffer even if total vertex count is more than 2^16.
   - Of course, if one submeh references wide range of vertices, we cannot use UInt16 index buffer so we still use UInt32 index buffer in such a case.
-- Reimplement Preview system with NDMF Preview System `#1131` `#1195`
+- Reimplement Preview system with NDMF Preview System `#1131` `#1195` `#1218`
   - This will prevent issues relates to Animation Mode bug.
   - This allows you to preview Remove Mesh components without selecting Mesh OR while in Animation Mode.
 - Improved Prefab Safe Set, which are used in MergePhysBone, MergeSkinnedMesh, FreezeBlendShape and more components `#1212`
   - This should improve compatibility with replacing base prefab, which is added in Unity 2022.
-- Allow multiple component for Remove Mesh components with API `#1216`
+- Allow multiple component for Remove Mesh components with API `#1216` `#1218`
   - This allows non-destructive tools to add Remove Mesh components even if Remove Mesh component are added before.
 
 ### Deprecated
@@ -63,7 +63,6 @@ The format is based on [Keep a Changelog].
 - Avatars with Visame Skinned Mesh disabled will not able to upload `#1202`
 - Avatar Optimizer does not support `Additive Reference Pose` `#1208`
 - Typo in menu for creating Asset Description `#1213`
-- `SupportsMultiple()` render filters ignore renderers with only one component attached `#1218`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog].
 - Avatars with Visame Skinned Mesh disabled will not able to upload `#1202`
 - Avatar Optimizer does not support `Additive Reference Pose` `#1208`
 - Typo in menu for creating Asset Description `#1213`
+- `SupportsMultiple()` render filters ignore renderers with only one component attached `#1218`
 
 ### Security
 

--- a/Editor/EditModePreview/AAORenderFilterBase.cs
+++ b/Editor/EditModePreview/AAORenderFilterBase.cs
@@ -48,7 +48,7 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
             }
 
             return componentsByRenderer
-                .Where(x => SupportsMultiple() ? x.Value.Count > 1 : x.Value.Count == 1)
+                .Where(x => SupportsMultiple() ? x.Value.Count >= 1 : x.Value.Count == 1)
                 .Select(pair => RenderGroup.For(pair.Key).WithData(pair.Value.ToArray()))
                 .ToImmutableList();
         }


### PR DESCRIPTION
AAORenderFilterBase was ignoring renderers where only one component is
attached, when `SupportsMultiple()` is true. This changes it to accept
one or more renderer in this case.
