### PR TITLE
fix: merge islands incorrectly when one island covers the other

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Animation for target renderer of Merge Skinned Mesh might be overridden by animation for source renderer `#1276`
+- Merge islands incorrectly when one island covers the other `#1278`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog].
     - We may relax some restriction in the future.
   - Because we have to check for each condition if we use AnyState but we can check for only one (in best case) with entry/exit, this generally reduces cost for checking an parameter in a state.
   - Combined with Entry / Exit to 1D BlendTree optimization, which is implemented in previous release, your AnyState layer may be optimized to 1D BlendTree.
-- Optimize Texture in Trace nad Optimize `#1181` `#1184` `#1193` `#1215` `#1225` `#1235` `#1268`
+- Optimize Texture in Trace nad Optimize `#1181` `#1184` `#1193` `#1215` `#1225` `#1235` `#1268` `#1278`
   - Avatar Optimizer will pack texture and tries to reduce the VRAM usage.
   - Currently liltoon is only supported.
 - `Copy Enablement Animation` to Merge Skinned Mesh `#1173`

--- a/Editor/Processors/TraceAndOptimize/OptimizeTexture.cs
+++ b/Editor/Processors/TraceAndOptimize/OptimizeTexture.cs
@@ -651,7 +651,7 @@ internal struct OptimizeTextureImpl {
                 if (islandI.MinPos.x <= islandJ.MinPos.x && islandJ.MaxPos.x <= islandI.MaxPos.x &&
                     islandI.MinPos.y <= islandJ.MinPos.y && islandJ.MaxPos.y <= islandI.MaxPos.y)
                 {
-                    islandI.OriginalIslands.AddRange(islandI.OriginalIslands);
+                    islandI.OriginalIslands.AddRange(islandJ.OriginalIslands);
                     islands.RemoveAt(j);
                     j--;
                     if (j < i) i--;


### PR DESCRIPTION
Closes #1277 です。