### PR TITLE
chore: Add conditional compile for VRCSDK API (for 1.8.0-beta.11)

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Fix non-VRChat project support `#1310`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ The format is based on [Keep a Changelog].
 - NRE if specified expression parameters is None `#1303`
   - This error only happens if you don't use Modular Avatar since Modular Avatar will assign parameters asset.
 - Show version name on NDMF Console `#1309`
+- Fix non-VRChat project support `#1310`
 
 ### Security
 

--- a/Editor/NewGameObjectAndAddComponent.cs
+++ b/Editor/NewGameObjectAndAddComponent.cs
@@ -41,7 +41,9 @@ namespace Anatawa12.AvatarOptimizer
         [MenuItem(BASE_PATH + MERGE_PHYSBONE, true, PRIORITY)]
         private static bool ValidateCreateMergePhysBone() => Selection.activeGameObject != null;
 
+#if AAO_VRCSDK3_AVATARS
         [MenuItem(BASE_PATH + MERGE_PHYSBONE, false, PRIORITY)]
         private static void CreateMergePhysBone() => CreateAndAddComponent<MergePhysBone>(MERGE_PHYSBONE);
+#endif
     }
 }

--- a/Editor/ObjectMapping/ObjectMappingContext.cs
+++ b/Editor/ObjectMapping/ObjectMappingContext.cs
@@ -48,7 +48,9 @@ namespace Anatawa12.AvatarOptimizer
                     switch (component)
                     {
                         case Animator _:
+#if AAO_VRCSDK3_AVATARS
                         case VRC.SDK3.Avatars.Components.VRCAvatarDescriptor _:
+#endif
 #if AAO_VRM0
                         case VRM.VRMBlendShapeProxy _:
 #endif


### PR DESCRIPTION
Fixed some compile errors I've found when using AvatarOptimizer in non-VRChat project.