### PR TITLE
perf: improve performance of AutoMergeBlendShape

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog].
 ### Added
 
 ### Changed
+- Performance improvements for AutoMergeBlendShape `#1327`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ The format is based on [Keep a Changelog].
 - Renamed debug options internally `#1228`
   - This will lose previously configured debug options.
   - However, debug options are not considered as Public API as stated in documents so this is not backward incompatible changes in semver 2.0.0 section 8.
-- Performance Improvements `#1234` `#1243` `#1240` `#1288` `#1304` `#1307` `#1314`
+- Performance Improvements `#1234` `#1243` `#1240` `#1288` `#1304` `#1307` `#1314` `#1327`
 - Transform gizmo are now hidden while you're editing box of Remove Mesh in Box `#1259`
   - This prevents mistakenly moving the Skinned Mesh Renderer while editing the box.
 - Make MergePhysBone implement `INetworkID` `#1260`

--- a/Editor/Processors/TraceAndOptimize/AutoMergeBlendShape.cs
+++ b/Editor/Processors/TraceAndOptimize/AutoMergeBlendShape.cs
@@ -7,6 +7,7 @@ using nadena.dev.ndmf;
 using Unity.Collections;
 using Unity.Jobs;
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace Anatawa12.AvatarOptimizer.Processors.TraceAndOptimizes;
 
@@ -23,13 +24,22 @@ class AutoMergeBlendShape: TraceAndOptimizePass<AutoMergeBlendShape>
         {
             if (state.Exclusions.Contains(skinnedMeshRenderer.gameObject)) continue; // manual exclusion
 
-            ErrorReport.WithContextObject(skinnedMeshRenderer, () => DoAutoMerge(context.GetMeshInfoFor(skinnedMeshRenderer), context));
+            ErrorReport.WithContextObject(skinnedMeshRenderer, () =>
+            {
+                Profiler.BeginSample("GetMeshInfoFor", skinnedMeshRenderer);
+                var meshInfo = context.GetMeshInfoFor(skinnedMeshRenderer);
+                Profiler.EndSample();
+                
+                DoAutoMerge(meshInfo, context);
+            });
         }
     }
 
     private static void DoAutoMerge(MeshInfo2 meshInfo2, BuildContext context)
     {
         var animationComponent = context.GetAnimationComponent(meshInfo2.SourceRenderer);
+        
+        Profiler.BeginSample("Compute merge keys");
         var groups = new Dictionary<MergeKey, List<string>>();
 
         foreach (var (name, weight) in meshInfo2.BlendShapes)
@@ -43,10 +53,17 @@ class AutoMergeBlendShape: TraceAndOptimizePass<AutoMergeBlendShape>
         }
 
         // nothing to merge
-        if (groups.Values.All(x => x.Count <= 1)) return;
+        if (groups.Values.All(x => x.Count <= 1))
+        {
+            Profiler.EndSample();
+            return;
+        }
+        Profiler.EndSample();
 
+        Profiler.BeginSample("Prepare merge");
         // prepare merge
         var buffers = meshInfo2.Vertices.Select(x => x.BlendShapeBuffer).Distinct().ToArray();
+        Profiler.EndSample();
 
         // bulk remove to optimize removing blendshape process
         var removeNames = new HashSet<string>();
@@ -59,6 +76,7 @@ class AutoMergeBlendShape: TraceAndOptimizePass<AutoMergeBlendShape>
         {
             // validate the blendShapes are simple enough to merge
             // if not, skip
+            Profiler.BeginSample("AutoMergeBlendShape: Validate");
             foreach (var buffer in buffers)
             {
                 float? commonFrameWeight = null;
@@ -80,6 +98,7 @@ class AutoMergeBlendShape: TraceAndOptimizePass<AutoMergeBlendShape>
                     }
                 }
             }
+            Profiler.EndSample();
 
             // validation passed, merge
             var newName = $"AAO_Merged_{string.Join("_", names)}_{i++}";
@@ -94,6 +113,7 @@ class AutoMergeBlendShape: TraceAndOptimizePass<AutoMergeBlendShape>
             meshInfo2.BlendShapes.Add((newName, key.defaultWeight));
             removeNames.UnionWith(names);
 
+            Profiler.BeginSample("AutoMergeBlendShape: Merge");
             // actually merge data
             foreach (var buffer in buffers)
             {
@@ -136,6 +156,8 @@ class AutoMergeBlendShape: TraceAndOptimizePass<AutoMergeBlendShape>
                 }
             }
 
+            Profiler.EndSample();
+            
             next_shape: ;
         }
 

--- a/Editor/Processors/TraceAndOptimize/AutoMergeBlendShape.cs
+++ b/Editor/Processors/TraceAndOptimize/AutoMergeBlendShape.cs
@@ -46,7 +46,7 @@ class AutoMergeBlendShape: TraceAndOptimizePass<AutoMergeBlendShape>
         if (groups.Values.All(x => x.Count <= 1)) return;
 
         // prepare merge
-        var buffers = meshInfo2.Vertices.Select(x => x.BlendShapeBuffer).ToArray();
+        var buffers = meshInfo2.Vertices.Select(x => x.BlendShapeBuffer).Distinct().ToArray();
 
         // bulk remove to optimize removing blendshape process
         var removeNames = new HashSet<string>();


### PR DESCRIPTION
This pass was obtaining the blendshape buffer for each vertex, then processing those buffers.
However, in practice, most vertices share the same buffer; this pass ignored this, and redid
the same work thousands of times as a result.

This reduces processing time from ~370ms to ~22ms on my main avatar.
