### PR TITLE
fix(VRM): Fix VRM BlendShape mapping

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- VRM: Fix BlendShape mapping [`#1375`](https://github.com/anatawa12/AvatarOptimizer/pull/1375)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- VRM: Fix BlendShape mapping [`#1375`](https://github.com/anatawa12/AvatarOptimizer/pull/1375)
 
 ### Security
 

--- a/Editor/ObjectMapping/ObjectMappingContext.cs
+++ b/Editor/ObjectMapping/ObjectMappingContext.cs
@@ -420,7 +420,7 @@ namespace Anatawa12.AvatarOptimizer
                 return mappedBindings
                     .Select(mapped => new VRM.BlendShapeBinding
                     {
-                        RelativePath = _mapping.MapPath(mapped.path, typeof(SkinnedMeshRenderer)),
+                        RelativePath = mapped.path,
                         Index = VProp.ParseBlendShapeIndex(mapped.propertyName),
                         Weight = binding.Weight
                     });
@@ -486,7 +486,7 @@ namespace Anatawa12.AvatarOptimizer
                 return mappedBindings
                     .Select(mapped => new UniVRM10.MorphTargetBinding
                     {
-                        RelativePath = _mapping.MapPath(mapped.path, typeof(SkinnedMeshRenderer)),
+                        RelativePath = mapped.path,
                         Index = VProp.ParseBlendShapeIndex(mapped.propertyName),
                         Weight = binding.Weight
                     });

--- a/Editor/ObjectMapping/ObjectMappingContext.cs
+++ b/Editor/ObjectMapping/ObjectMappingContext.cs
@@ -437,8 +437,8 @@ namespace Anatawa12.AvatarOptimizer
             if (vrm10Object == null) return;
             ValidateTemporaryAsset(vrm10Object);
             if (!_fixedObjects.Add(vrm10Object)) return;
-            foreach (var customClip in vrm10Object.Expression.CustomClips)
-                FixVRM10Expression(customClip);
+            foreach (var clip in vrm10Object.Expression.Clips)
+                FixVRM10Expression(clip.Clip);
 
             vrm10Object.FirstPerson.Renderers = vrm10Object.FirstPerson.Renderers
                 .Select(r => new UniVRM10.RendererFirstPersonFlags


### PR DESCRIPTION
Two small related fixes around VRM BlendShapes, with self-explanatory commit messages.

- Fixed VRM0 BlendShape / VRM1 Expression target renderer reference/path double mapped.
- FIxed VRM1 default Expressions not processed. (only Custom Expressions are processed)