### PR TITLE
perf: avoid fetching mask texture data on change check callbacks

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
-- Performance improvements
+- Performance improvements `#1380`
 
 ### Security
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Performance improvements
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
-- Performance improvements
+- Performance improvements `#1380`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Performance improvements
 
 ### Security
 

--- a/Editor/EditModePreview/RemoveMeshByMaskRenderFilter.cs
+++ b/Editor/EditModePreview/RemoveMeshByMaskRenderFilter.cs
@@ -56,9 +56,13 @@ namespace Anatawa12.AvatarOptimizer.EditModePreview
                     }
                     else
                     {
-                        textureWidth = context.Observe(materialSetting.mask, m => m.width);
-                        textureHeight = context.Observe(materialSetting.mask, m => m.height);
-                        pixels = context.Observe(materialSetting.mask, m => m.GetPixels32(), Utils.Color32ArrayEquals);
+                        // Register to be re-evaluted when the texture changes. We avoid using GetPixels32 here for
+                        // performance reasons, as this is frequently re-invoked by NDMF's PropertyMonitor.
+                        context.Observe(materialSetting.mask, m => (m.width, m.height, m.imageContentsHash));
+
+                        textureWidth = materialSetting.mask.width;
+                        textureHeight = materialSetting.mask.height;
+                        pixels = materialSetting.mask.GetPixels32();
                     }
                     using var pixelsJob = new NativeArray<Color32>(pixels, Allocator.TempJob);
 


### PR DESCRIPTION
NDMF invokes change checks (Observe callbacks) periodically to check for changes
caused by code that does not properly register change events. While this is time-sliced,
if any single callback takes too long, it can cause poor editor performance.

In AAO, we were checking for changes in mask textures in such a callback; this check retrieved
the `GetPixels32` array, which is an expensive operation which could take dozens of ms in some cases
(particularly since the time-slicing was on a per-object basis, so if the same mask was used by
multiple objects, the overhead adds up).

While NDMF should probably change the time slicing to work on a per-listener basis, and/or add
special handling for `Texture2D`, on the AAO side we can more efficiently perform change checks by\
using unity's built-in image hash functions instead of comparing contents directly.
