### PR TITLE
Add missing `[BurstCompile]` to jobs

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Add missing `[BurstCompile]` to jobs [`#1418`](https://github.com/anatawa12/AvatarOptimizer/pull/1418)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Add missing `[BurstCompile]` to jobs [`#1418`](https://github.com/anatawa12/AvatarOptimizer/pull/1418)
 
 ### Security
 

--- a/Editor/Processors/TraceAndOptimize/AutoMergeBlendShape.cs
+++ b/Editor/Processors/TraceAndOptimize/AutoMergeBlendShape.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Anatawa12.AvatarOptimizer.AnimatorParsersV2;
 using Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes;
 using nadena.dev.ndmf;
+using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 using UnityEngine;
@@ -209,6 +210,7 @@ class AutoMergeBlendShape: TraceAndOptimizePass<AutoMergeBlendShape>
         public static bool operator !=(MergeKey left, MergeKey right) => !left.Equals(right);
     }
 
+    [BurstCompile]
     struct MergeBlendShapeJob : IJobParallelFor
     {
         public NativeArray<Vector3> vertices;


### PR DESCRIPTION
`MergeBlendShapeJob` is missing `[BurstCompile]` attribute, but any other jobs in this library has `[BurstCompile]` attribute.
So this may be not intended.