### PR TITLE
Add Burst to dependencies directly

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Add Burst to dependencies directly `#1419`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Add Burst to dependencies directly `#1419`
 
 ### Security
 

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "vpmDependencies": {
     "nadena.dev.ndmf": "^1.6.0",
     "com.vrchat.avatars": ">=3.7.0 <3.8.0"
+  },
+  "dependencies": {
+    "com.unity.burst": "1.8.7"
   }
 }


### PR DESCRIPTION
Currently, Burst package is referenced indirectly via `com.vrchat.avatars` => `com.vrchat.base` => `com.unity.burst`.

But this library directly uses `[BurstCompile]` attribute.

Referencing Burst package directly will be much robust, and make us be able to use recent Burst package.