### PR TITLE
feat: Add AssetDescription for PVLController

### DIFF
--- a/ExternalDescriptions/PVLController.asset
+++ b/ExternalDescriptions/PVLController.asset
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 672cf279ebc041f5b87addc7c6c980bb, type: 3}
+  m_Name: PVLController
+  m_EditorClassIdentifier: 
+  comment: "PVLController -VirtualLens2\u7528\u304A\u624B\u8EFD\u81EA\u64AE\u308A\u30AE\u30DF\u30C3\u30AF-\nhttps://pogapoganyaa.booth.pm/items/5245784\n\n*
+    NDMF Plugin ID: PogapogaEditor.PogapogaComponent.PVLController\n* Meaningless
+    Componments \u306F PVLController.RemoveComponent() \u3067\u524A\u9664\u3055\u308C\u3066\u3044\u308B\u3082\u306E\u304C\u5BFE\u8C61\u3002\n*
+    PVLController.prefab \u4EE5\u5916\u306E prefab \u3092\u4F7F\u3046\u5834\u5408\u306B\u5404\u7A2E\u30B3\u30F3\u30DD\u30FC\u30CD\u30F3\u30C8\u304C\u6B8B\u7559\u3057\u3066\u3057\u307E\u3046\u3002"
+  meaninglessComponents:
+  - className: PVLController
+    guid: d19b3ba2d027f4d40a06d2c5405b4438
+    fileID: 11500000
+  - className: PVLControllerCustomCameraPositionSetting
+    guid: 0fc986c693abd0144a6aea5ac849a1d5
+    fileID: 11500000
+  - className: PVLControllerCustomAimPositionSetting
+    guid: f0511bcc9a7263743bf359cd5531f171
+    fileID: 11500000
+  - className: PvlcCustomPresetSettingParameter
+    guid: 9ac82501f7556c944be3228f1d4a9a4f
+    fileID: 11500000
+  - className: PvlcCustomPresetSettingManager
+    guid: f159875df54e387468f28676d205a939
+    fileID: 11500000
+  - className: PvlcCustomPresetSettingExporter
+    guid: 4f19638032163f34092ff6d737d24778
+    fileID: 11500000
+  - className: PVLControllerIntegralSwitcher
+    guid: 742c0653f0de90a44a3f40eb1c43d58e
+    fileID: 11500000
+  - className: DronePositionMarkerInfo
+    guid: 34e95baf529a596419b8a4c7efb489e6
+    fileID: 11500000
+  - className: ButtonOperatedDroneInfo
+    guid: 5596c2ba235e1f2469e3b3a35c62f591
+    fileID: 11500000
+  parametersReadByExternalTools: []
+  parametersChangedByExternalTools: []

--- a/ExternalDescriptions/PVLController.asset.meta
+++ b/ExternalDescriptions/PVLController.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f2125888d52e764585d56b5a2b167c8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
PVLController -VirtualLens2用お手軽自撮りギミック-
https://pogapoganyaa.booth.pm/items/5245784

* NDMF Plugin ID: PogapogaEditor.PogapogaComponent.PVLController
* Meaningless Componments は PVLController.RemoveComponent() で削除されているものが対象。
* PVLController.prefab 以外の prefab を使う場合に各種コンポーネントが残留してしまう。

<hr>
(上記内容を AssetDescription Comment にも記載)