### PR TITLE
fix: The rotation / position of global physbone collider may be altered

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Parameter is not applied in MergePhysBone `#1448`
+- The rotation / position of global physbone collider may be altered `#1453`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Parameter is not applied in MergePhysBone `#1448`
+- The rotation / position of global physbone collider may be altered `#1453`
 
 ### Security
 

--- a/Editor/APIInternal/ComponentInfos.VRCSDK.cs
+++ b/Editor/APIInternal/ComponentInfos.VRCSDK.cs
@@ -199,7 +199,12 @@ namespace Anatawa12.AvatarOptimizer.APIInternal.VRCSDK
                 {
                     case VRCAvatarDescriptor.ColliderConfig.State.Automatic:
                     case VRCAvatarDescriptor.ColliderConfig.State.Custom:
-                        collector.AddDependency(collider.transform).EvenIfDependantDisabled();
+                        if (collider.transform) {
+                            // The position of parent bone (iow local position of transform) will be used to 
+                            // determine the position and rotation of the collider
+                            collector.AddDependency(collider.transform).EvenIfDependantDisabled();
+                            collector.AddDependency(collider.transform.parent).EvenIfDependantDisabled();
+                        }
                         break;
                     case VRCAvatarDescriptor.ColliderConfig.State.Disabled:
                         break;


### PR DESCRIPTION
According to https://nekolobby.niri.la/notes/a7vq7z0lxj (https://note.com/labo405/n/nac5615af9b0e)

> アバターコライダーはPhysBoneと似た性質を持っており、指定オブジェクトの【親オブジェクトの位置を基準、指定オブジェクトをコライダーの方向】として動作します。