### PR TITLE
Add MergeMaterial component and deprecate MergeToonLit component

### DIFF
--- a/Editor/EditSkinnedMeshComponentUtil.cs
+++ b/Editor/EditSkinnedMeshComponentUtil.cs
@@ -203,6 +203,7 @@ namespace Anatawa12.AvatarOptimizer
                 [typeof(MergeSkinnedMesh)] = x => new MergeSkinnedMeshProcessor((MergeSkinnedMesh)x),
                 [typeof(FreezeBlendShape)] = x => new FreezeBlendShapeProcessor((FreezeBlendShape)x),
                 [typeof(MergeToonLitMaterial)] = x => new MergeToonLitMaterialProcessor((MergeToonLitMaterial)x),
+                [typeof(MergeMaterial)] = x => new MergeMaterialProcessor((MergeMaterial)x),
                 [typeof(RemoveMeshInBox)] = x => new RemoveMeshInBoxProcessor((RemoveMeshInBox)x),
                 [typeof(RemoveMeshByBlendShape)] = x => new RemoveMeshByBlendShapeProcessor((RemoveMeshByBlendShape)x),
                 [typeof(RemoveMeshByMask)] = x => new RemoveMeshByMaskProcessor((RemoveMeshByMask)x),

--- a/Editor/Inspector/MergeMaterialEditor.cs
+++ b/Editor/Inspector/MergeMaterialEditor.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Anatawa12.AvatarOptimizer
+{
+    [CustomEditor(typeof(MergeMaterial))]
+    internal class MergeMaterialEditor : AvatarTagComponentEditorBase
+    {
+        private Material?[] _upstreamMaterials = null!; // initialized in OnEnable
+        private Material[] _materials = null!; // initialized in OnEnable
+
+        private Material[] _candidateMaterials = null!; // initialized in OnEnable
+        private string[] _candidateNames = null!; // initialized in OnEnable
+
+        private Texture[]? _generatedPreviews;
+
+        private readonly Func<MergeMaterial.MergeSource> _createNewSource;
+        private readonly Func<MergeMaterial.MergeInfo> _createNewMergeInfo;
+
+        public MergeMaterialEditor()
+        {
+            _createNewSource = () => new MergeMaterial.MergeSource
+                { material = null }; // TODO: consider create material selection
+            _createNewMergeInfo = () => new MergeMaterial.MergeInfo
+                { source = new[] { _createNewSource() } };
+        }
+
+        private static void DrawList<T>(
+            [AllowNull] ref T[] array,
+            string addButton,
+            Action<T, int> drawer,
+            Func<T>? newElement,
+            bool noEmpty = false,
+            Action? postButtons = null,
+            Action? onMoved = null,
+            Action<T>? onRemoved = null,
+            Action<T>? onAdded = null
+        )
+        {
+            if (array == null) array = Array.Empty<T>();
+            for (var i = 0; i < array.Length; i++)
+            {
+                drawer(array[i], i);
+
+                GUILayout.BeginHorizontal();
+                using (new EditorGUI.DisabledScope(i == 0))
+                {
+                    if (GUILayout.Button("▲"))
+                    {
+                        (array[i], array[i - 1]) = (array[i - 1], array[i]);
+                        onMoved?.Invoke();
+                    }
+                }
+
+                using (new EditorGUI.DisabledScope(i == array.Length - 1))
+                {
+                    if (GUILayout.Button("▼"))
+                    {
+                        (array[i], array[i + 1]) = (array[i + 1], array[i]);
+                        onMoved?.Invoke();
+                    }
+                }
+
+                using (new EditorGUI.DisabledScope(noEmpty && array.Length == 1))
+                {
+                    if (GUILayout.Button("✗"))
+                    {
+                        var removing = array[i];
+                        ArrayUtility.RemoveAt(ref array, i);
+                        onRemoved?.Invoke(removing);
+                        i--;
+                    }
+                }
+
+                GUILayout.EndHorizontal();
+                postButtons?.Invoke();
+            }
+
+            using (new EditorGUI.DisabledScope(newElement == null))
+                if (GUILayout.Button(addButton))
+                {
+                    if (newElement == null) throw new InvalidOperationException();
+                    T element;
+                    ArrayUtility.Add(ref array, element = newElement());
+                    onAdded?.Invoke(element);
+                }
+
+        }
+
+        protected override void OnInspectorGUIInner()
+        {
+            EditorGUI.BeginChangeCheck();
+
+            var component = (MergeMaterial)target;
+
+            DrawList(ref component.merges, AAOL10N.Tr("MergeMaterial:button:Add Merged Material"),
+                (componentMerge, i) =>
+                {
+                    DrawList(ref componentMerge.source, AAOL10N.Tr("MergeMaterial:button:Add Source"),
+                        (mergeSource, _) =>
+                        {
+                            var found = _materials.FirstOrDefault(mat => mat == mergeSource.material);
+                            _candidateNames[0] = found != null ? found.name : "(invalid)";
+                            EditorGUI.BeginChangeCheck();
+                            var newIndex = EditorGUILayout.Popup(0, _candidateNames);
+                            if (EditorGUI.EndChangeCheck() && newIndex != 0)
+                                mergeSource.material = _candidateMaterials[newIndex - 1];
+
+                            EditorGUI.BeginChangeCheck();
+                            mergeSource.targetRect = EditorGUILayout.RectField(mergeSource.targetRect);
+                        },
+                        _candidateMaterials.Length != 0 ? _createNewSource : null,
+                        onMoved: OnChanged,
+                        onAdded: _ => OnChanged(),
+                        onRemoved: _ => OnChanged()
+                    );
+
+                    componentMerge.textureSize =
+                        EditorGUILayout.Vector2IntField(AAOL10N.Tr("MergeMaterial:label:Texture Size"),
+                            componentMerge.textureSize);
+
+                    componentMerge.mergedFormat =
+                        (MergeMaterial.MergedTextureFormat)EditorGUILayout.EnumPopup("Format",
+                            componentMerge.mergedFormat);
+
+                    var preview = _generatedPreviews != null ? _generatedPreviews[i] : Assets.PreviewHereTex;
+                    EditorGUILayout.LabelField(new GUIContent(preview), GUILayout.MaxHeight(256),
+                        GUILayout.MaxHeight(256));
+
+                    Utils.HorizontalLine();
+                },
+                _candidateMaterials.Length != 0 ? _createNewMergeInfo : null,
+                postButtons: () => Utils.HorizontalLine(),
+                onMoved: OnChanged,
+                onAdded: _ => OnChanged(),
+                onRemoved: _ => OnChanged()
+            );
+
+            if (EditorGUI.EndChangeCheck())
+                OnChanged();
+
+            if (GUILayout.Button(AAOL10N.Tr("MergeMaterial:button:Generate Preview")))
+            {
+                // TODO: implement preview generation
+                //_generatedPreviews = MergeMaterialProcessor.GenerateTextures(component, _upstreamMaterials, false);
+            }
+        }
+
+        private void OnChanged() => OnChanged(true);
+
+        private void OnChanged(bool dirty)
+        {
+            _generatedPreviews = null;
+            var component = (MergeMaterial)target;
+            if (dirty) EditorUtility.SetDirty(component);
+            var usedMaterials =
+                new HashSet<Material>(component.merges.SelectMany(x =>
+                    x.source.Select(y => y.material).OfType<Material>()));
+            _candidateMaterials = _materials.Where(mat => !usedMaterials.Contains(mat)).ToArray();
+            _candidateNames = new[] { "" }.Concat(_candidateMaterials.Select(mat => mat.name)).ToArray();
+        }
+
+        private void OnEnable()
+        {
+            var component = (MergeMaterial)target;
+
+            _upstreamMaterials = EditSkinnedMeshComponentUtil
+                .GetMaterials(component.GetComponent<SkinnedMeshRenderer>(), component);
+            _materials = _upstreamMaterials.ToArray()!;
+            OnChanged(dirty: false);
+        }
+    }
+}

--- a/Editor/Inspector/MergeMaterialEditor.cs.meta
+++ b/Editor/Inspector/MergeMaterialEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c4de48953a8748398a182b36179ee103
+timeCreated: 1756567295

--- a/Editor/Processors/SkinnedMeshes/MergeMaterialProcessor.cs
+++ b/Editor/Processors/SkinnedMeshes/MergeMaterialProcessor.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using nadena.dev.ndmf;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using Object = UnityEngine.Object;
+
+namespace Anatawa12.AvatarOptimizer.Processors.SkinnedMeshes
+{
+    internal class MergeMaterialProcessor : EditSkinnedMeshProcessor<MergeMaterial>
+    {
+        private static readonly int MainTexProp = Shader.PropertyToID("_MainTex");
+        private static readonly int MainTexStProp = Shader.PropertyToID("_MainTex_ST");
+        private static readonly int RectProp = Shader.PropertyToID("_Rect");
+
+        private static Material? _helperMaterial;
+
+        private static Material HelperMaterial =>
+            _helperMaterial != null ? _helperMaterial : _helperMaterial = new Material(Assets.MergeTextureHelper);
+
+        public MergeMaterialProcessor(MergeMaterial component) : base(component)
+        {
+        }
+
+        public override EditSkinnedMeshProcessorOrder ProcessOrder => EditSkinnedMeshProcessorOrder.AfterRemoveMesh;
+
+        public override void Process(BuildContext context, MeshInfo2 target)
+        {
+#if false
+            // compute usages. AdditionalTemporal is usage count for now.
+            // if #usages is not zero for merging triangles
+            var users = new Dictionary<Vertex, int>();
+
+            foreach (var v in target.Vertices) users[v] = 0;
+
+            foreach (var targetSubMesh in target.SubMeshes)
+            foreach (var v in targetSubMesh.Vertices.Distinct())
+                users[v]++;
+
+            // compute per-material data
+            var mergingIndices = ComputeMergingIndices(target.SubMeshes.Count);
+            var targetRectForMaterial = new Rect[target.SubMeshes.Count];
+            foreach (var componentMerge in Component.merges)
+            foreach (var mergeSource in componentMerge.source)
+                targetRectForMaterial[mergeSource.materialIndex] = mergeSource.targetRect;
+
+            // map UVs
+            for (var subMeshI = 0; subMeshI < target.SubMeshes.Count; subMeshI++)
+            {
+                if (mergingIndices[subMeshI])
+                {
+                    // the material is for merge.
+                    var subMesh = target.SubMeshes[subMeshI];
+                    var targetRect = targetRectForMaterial[subMeshI];
+                    var vertexCache = new Dictionary<Vertex, Vertex>();
+                    for (var i = 0; i < subMesh.Vertices.Count; i++)
+                    {
+                        if (vertexCache.TryGetValue(subMesh.Vertices[i], out var cached))
+                        {
+                            subMesh.Vertices[i] = cached;
+                            continue;
+                        }
+                        if (users[subMesh.Vertices[i]] != 1)
+                        {
+                            // if there are multiple users for the vertex: duplicate it
+                            var cloned = subMesh.Vertices[i].Clone();
+                            target.VerticesMutable.Add(cloned);
+
+                            users[subMesh.Vertices[i]]--;
+
+                            vertexCache[subMesh.Vertices[i]] = cloned;
+                            subMesh.Vertices[i] = cloned;
+                        }
+                        else
+                        {
+                            vertexCache[subMesh.Vertices[i]] = subMesh.Vertices[i];
+                        }
+
+                        subMesh.Vertices[i].TexCoord0 = MapUV(subMesh.Vertices[i].TexCoord0, targetRect);
+                    }
+                }
+            }
+
+            // merge submeshes
+            target.FlattenMultiPassRendering("Merge Toon Lit");
+            var copied = target.SubMeshes.Where((_, i) => !mergingIndices[i]);
+            var materials = target.SubMeshes.Select(x => x.SharedMaterial).ToArray();
+            var merged = Component.merges.Select(x => new SubMesh(
+                x.source.SelectMany(src => target.SubMeshes[src.materialIndex].Triangles).ToList(),
+                CreateMaterial(GenerateTexture(x, materials, true))));
+            var subMeshes = copied.Concat(merged).ToList();
+            target.SubMeshes.Clear();
+            target.SubMeshes.AddRange(subMeshes);
+#endif
+        }
+
+        private Vector2 MapUV(Vector2 vector2, Rect destSourceRect) =>
+            new Vector2(vector2.x % 1, vector2.y % 1) * new Vector2(destSourceRect.width, destSourceRect.height) 
+            + new Vector2(destSourceRect.x, destSourceRect.y);
+
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        /// <summary>
+        /// </summary>
+        /// <returns>bitarray[i] is true if the materials[i] ill be merged to other material</returns>
+        public BitArray ComputeMergingIndices(int subMeshCount)
+        {
+            var mergingIndices = new BitArray(subMeshCount);
+#if false
+            foreach (var mergeInfo in Component.merges)
+            foreach (var source in mergeInfo.source)
+                mergingIndices[source.materialIndex] = true;
+#endif
+            return mergingIndices;
+        }
+
+        private Material?[] CreateMaterials(BitArray mergingIndices, Material?[] upstream, bool fast)
+        {
+            var copied = upstream.Where((_, i) => !mergingIndices[i]);
+            if (fast)
+            {
+                return copied.Concat(Component.merges.Select(x => new Material(Assets.ToonLitShader))).ToArray();
+            }
+            else
+            {
+                // slow mode: generate texture actually
+                return copied.Concat(GenerateTextures(Component, upstream, false).Select(CreateMaterial)).ToArray();
+            }
+        }
+
+        private static Material CreateMaterial(Texture texture)
+        {
+            var mat = new Material(Assets.ToonLitShader);
+            mat.SetTexture(MainTexProp, texture);
+            return mat;
+        }
+
+        public static Texture[] GenerateTextures(MergeMaterial config, Material?[] materials, bool compress)
+        {
+            return config.merges.Select(x => GenerateTexture(x, materials, compress)).ToArray();
+        }
+
+        private static TextureFormat BaseTextureFormat(MergeMaterial.MergedTextureFormat finalFormat)
+        {
+            switch (finalFormat)
+            {
+                case MergeMaterial.MergedTextureFormat.Alpha8:
+                case MergeMaterial.MergedTextureFormat.ARGB4444:
+                case MergeMaterial.MergedTextureFormat.RGB24:
+                case MergeMaterial.MergedTextureFormat.RGBA32:
+                case MergeMaterial.MergedTextureFormat.ARGB32:
+                case MergeMaterial.MergedTextureFormat.RGB565:
+                case MergeMaterial.MergedTextureFormat.R16:
+                case MergeMaterial.MergedTextureFormat.RGBA4444:
+                case MergeMaterial.MergedTextureFormat.BGRA32:
+                case MergeMaterial.MergedTextureFormat.RG16:
+                case MergeMaterial.MergedTextureFormat.R8:
+                    return (TextureFormat) finalFormat;
+                case MergeMaterial.MergedTextureFormat.BC4:
+                    return TextureFormat.R8;
+                case MergeMaterial.MergedTextureFormat.BC5:
+                    return TextureFormat.RG16;
+                case MergeMaterial.MergedTextureFormat.DXT1:
+                    return TextureFormat.RGB24;
+                case MergeMaterial.MergedTextureFormat.DXT5:
+                case MergeMaterial.MergedTextureFormat.BC7:
+                    return TextureFormat.RGBA32;
+                case MergeMaterial.MergedTextureFormat.ASTC_4x4:
+                case MergeMaterial.MergedTextureFormat.ASTC_5x5:
+                case MergeMaterial.MergedTextureFormat.ASTC_6x6:
+                case MergeMaterial.MergedTextureFormat.ASTC_8x8:
+                case MergeMaterial.MergedTextureFormat.ASTC_10x10:
+                case MergeMaterial.MergedTextureFormat.ASTC_12x12:
+                    return TextureFormat.RGBA32;
+                case MergeMaterial.MergedTextureFormat.Default:
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(finalFormat), finalFormat, null);
+            }
+        }
+
+        private static bool IsCompressedFormat(MergeMaterial.MergedTextureFormat finalFormat)
+        {
+            switch (finalFormat)
+            {
+                case MergeMaterial.MergedTextureFormat.Alpha8:
+                case MergeMaterial.MergedTextureFormat.ARGB4444:
+                case MergeMaterial.MergedTextureFormat.RGB24:
+                case MergeMaterial.MergedTextureFormat.RGBA32:
+                case MergeMaterial.MergedTextureFormat.ARGB32:
+                case MergeMaterial.MergedTextureFormat.RGB565:
+                case MergeMaterial.MergedTextureFormat.R16:
+                case MergeMaterial.MergedTextureFormat.RGBA4444:
+                case MergeMaterial.MergedTextureFormat.BGRA32:
+                case MergeMaterial.MergedTextureFormat.RG16:
+                case MergeMaterial.MergedTextureFormat.R8:
+                    return false;
+                case MergeMaterial.MergedTextureFormat.DXT1:
+                case MergeMaterial.MergedTextureFormat.DXT5:
+                case MergeMaterial.MergedTextureFormat.BC7:
+                case MergeMaterial.MergedTextureFormat.BC4:
+                case MergeMaterial.MergedTextureFormat.BC5:
+                case MergeMaterial.MergedTextureFormat.ASTC_4x4:
+                case MergeMaterial.MergedTextureFormat.ASTC_5x5:
+                case MergeMaterial.MergedTextureFormat.ASTC_6x6:
+                case MergeMaterial.MergedTextureFormat.ASTC_8x8:
+                case MergeMaterial.MergedTextureFormat.ASTC_10x10:
+                case MergeMaterial.MergedTextureFormat.ASTC_12x12:
+                    return true;
+                case MergeMaterial.MergedTextureFormat.Default:
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(finalFormat), finalFormat, null);
+            }
+        }
+
+        private static RenderTextureFormat GetRenderTarget(MergeMaterial.MergedTextureFormat finalFormat)
+        {
+            switch (finalFormat)
+            {
+                case MergeMaterial.MergedTextureFormat.ARGB4444:
+                case MergeMaterial.MergedTextureFormat.RGBA4444:
+                    return RenderTextureFormat.ARGB4444;
+                // 8 bit for each channel
+                case MergeMaterial.MergedTextureFormat.Alpha8:
+                case MergeMaterial.MergedTextureFormat.RGB24:
+                case MergeMaterial.MergedTextureFormat.RGBA32:
+                case MergeMaterial.MergedTextureFormat.ARGB32:
+                case MergeMaterial.MergedTextureFormat.BGRA32:
+                case MergeMaterial.MergedTextureFormat.DXT1:
+                case MergeMaterial.MergedTextureFormat.DXT5:
+                case MergeMaterial.MergedTextureFormat.BC7:
+                    return RenderTextureFormat.ARGB32;
+                case MergeMaterial.MergedTextureFormat.RGB565:
+                    return RenderTextureFormat.RGB565;
+                case MergeMaterial.MergedTextureFormat.R16:
+                    return RenderTextureFormat.R16;
+                case MergeMaterial.MergedTextureFormat.RG16:
+                case MergeMaterial.MergedTextureFormat.BC5:
+                    return RenderTextureFormat.RG16;
+                case MergeMaterial.MergedTextureFormat.R8:
+                case MergeMaterial.MergedTextureFormat.BC4:
+                    return RenderTextureFormat.R8;
+                case MergeMaterial.MergedTextureFormat.ASTC_4x4:
+                case MergeMaterial.MergedTextureFormat.ASTC_5x5:
+                case MergeMaterial.MergedTextureFormat.ASTC_6x6:
+                case MergeMaterial.MergedTextureFormat.ASTC_8x8:
+                case MergeMaterial.MergedTextureFormat.ASTC_10x10:
+                case MergeMaterial.MergedTextureFormat.ASTC_12x12:
+                    return RenderTextureFormat.ARGB32;
+                case MergeMaterial.MergedTextureFormat.Default:
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(finalFormat), finalFormat, null);
+            }
+        }
+
+        private static Texture GenerateTexture(
+            MergeMaterial.MergeInfo mergeInfo,
+            Material?[] materials,
+            bool compress
+        )
+        {
+            var texWidth = mergeInfo.textureSize.x;
+            var texHeight = mergeInfo.textureSize.y;
+            var finalFormat = mergeInfo.mergedFormat;
+            if (finalFormat == MergeMaterial.MergedTextureFormat.Default)
+#if UNITY_ANDROID || UNITY_IOS
+                finalFormat = MergeMaterial.MergedTextureFormat.ASTC_6x6;
+#else
+                finalFormat = MergeMaterial.MergedTextureFormat.DXT5;
+#endif
+
+            // use compatible format
+            var targetFormat = GraphicsFormatUtility.GetGraphicsFormat(GetRenderTarget(finalFormat), RenderTextureReadWrite.Default);
+            targetFormat = SystemInfo.GetCompatibleFormat(targetFormat, FormatUsage.Render);
+            var target = new RenderTexture(texWidth, texHeight, 0, targetFormat);
+
+#if falas
+            foreach (var source in mergeInfo.source)
+            {
+                var sourceMat = materials[source.materialIndex]!; // selected material should not be null
+                var sourceTex = sourceMat.GetTexture(MainTexProp);
+                var sourceTexSt = sourceMat.GetVector(MainTexStProp);
+                HelperMaterial.SetTexture(MainTexProp, sourceTex);
+                HelperMaterial.SetVector(MainTexStProp, sourceTexSt);
+                HelperMaterial.SetVector(RectProp,
+                    new Vector4(source.targetRect.x, source.targetRect.y, source.targetRect.width,
+                        source.targetRect.height));
+                Graphics.Blit(sourceTex, target, HelperMaterial);
+            }
+#endif
+
+            var texture = CopyFromRenderTarget(target, finalFormat);
+
+            DestroyTracker.DestroyImmediate(target);
+
+            if (compress && IsCompressedFormat(finalFormat))
+                EditorUtility.CompressTexture(texture, (TextureFormat)finalFormat, TextureCompressionQuality.Normal);
+
+            Utils.Assert(texture.format == (TextureFormat)finalFormat, 
+                $"TextureFormat mismatch: expected {finalFormat} but was {texture.format}");
+
+            return texture;
+        }
+
+        private static Texture2D CopyFromRenderTarget(RenderTexture source, MergeMaterial.MergedTextureFormat finalFormat)
+        {
+            var prev = RenderTexture.active;
+            var texture = new Texture2D(source.width, source.height, BaseTextureFormat(finalFormat), true);
+            
+            try
+            {
+                RenderTexture.active = source;
+                texture.ReadPixels(new Rect(0, 0, texture.width, texture.height), 0, 0);
+                texture.Apply();
+            }
+            finally
+            {
+                RenderTexture.active = prev;
+            }
+
+            return texture;
+        }
+
+        public override IMeshInfoComputer GetComputer(IMeshInfoComputer upstream) => new MeshInfoComputer(this, upstream);
+
+        class MeshInfoComputer : AbstractMeshInfoComputer
+        {
+            private readonly MergeMaterialProcessor _processor;
+
+            public MeshInfoComputer(MergeMaterialProcessor processor, IMeshInfoComputer upstream) : base(upstream)
+                => _processor = processor;
+
+            public override Material?[] Materials(bool fast = true)
+            {
+                var upstream = base.Materials(fast);
+                return _processor.CreateMaterials(_processor.ComputeMergingIndices(upstream.Length), upstream, fast);
+            }
+        }
+    }
+}

--- a/Editor/Processors/SkinnedMeshes/MergeMaterialProcessor.cs.meta
+++ b/Editor/Processors/SkinnedMeshes/MergeMaterialProcessor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8e05e25734f94202923075b38efe3de3
+timeCreated: 1756570247

--- a/Runtime/MergeMaterial.cs
+++ b/Runtime/MergeMaterial.cs
@@ -1,0 +1,124 @@
+using System;
+using UnityEngine;
+
+namespace Anatawa12.AvatarOptimizer
+{
+    [AddComponentMenu("Avatar Optimizer/AAO Merge Material")]
+    [DisallowMultipleComponent]
+    [HelpURL("https://vpm.anatawa12.com/avatar-optimizer/ja/docs/reference/merge-material/")]
+    internal class MergeMaterial : EditSkinnedMeshComponent
+    {
+        public MergeInfo[] merges = Array.Empty<MergeInfo>();
+
+        [Serializable]
+        internal class MergeInfo
+        {
+            public MergeSource[] source = Array.Empty<MergeSource>();
+
+            public MergedTextureFormat mergedFormat;
+
+            // must be power of two. 13 (2^13 = 8192) is upper limit.
+            public Vector2Int textureSize = new Vector2Int(2048, 2048);
+        }
+
+        [Serializable]
+        internal class MergeSource
+        {
+            public Material? material;
+            public Rect targetRect = new Rect(0, 0, 1, 1);
+        }
+
+        /// <summary>
+        /// Subset of <see cref="UnityEngine.TextureFormat"/>
+        /// </summary>
+        public enum MergedTextureFormat
+        {
+            // There We forced non-linear color space for now so I disabled floating point image formats.
+#if UNITY_ANDROID || UNITY_IOS
+        [InspectorName("Default (ASTC 6x6)")]
+#else
+            [InspectorName("Default (DXT5)")]
+#endif
+            Default = 0,
+
+            // ReSharper disable InconsistentNaming
+            Alpha8 = TextureFormat.Alpha8,
+            ARGB4444 = TextureFormat.ARGB4444,
+            RGB24 = TextureFormat.RGB24,
+            RGBA32 = TextureFormat.RGBA32,
+            ARGB32 = TextureFormat.ARGB32,
+            RGB565 = TextureFormat.RGB565,
+            R16 = TextureFormat.R16,
+            DXT1 = TextureFormat.DXT1,
+            DXT5 = TextureFormat.DXT5,
+            RGBA4444 = TextureFormat.RGBA4444,
+            BGRA32 = TextureFormat.BGRA32,
+
+            //RHalf = TextureFormat.RHalf, // floating point
+            //RGHalf = TextureFormat.RGHalf, // floating point
+            //RGBAHalf = TextureFormat.RGBAHalf, // floating point
+            //RFloat = TextureFormat.RFloat, // floating point
+            //RGFloat = TextureFormat.RGFloat, // floating point
+            //RGBAFloat = TextureFormat.RGBAFloat, // floating point
+            //YUY2 = TextureFormat.YUY2,
+            //RGB9e5Float = TextureFormat.RGB9e5Float,
+            //BC6H = TextureFormat.BC6H,
+            BC7 = TextureFormat.BC7,
+            BC4 = TextureFormat.BC4,
+            BC5 = TextureFormat.BC5,
+
+            //DXT1Crunched = TextureFormat.DXT1Crunched,
+            //DXT5Crunched = TextureFormat.DXT5Crunched,
+            //PVRTC_RGB2 = TextureFormat.PVRTC_RGB2,
+            //PVRTC_RGBA2 = TextureFormat.PVRTC_RGBA2,
+            //PVRTC_RGB4 = TextureFormat.PVRTC_RGB4,
+            //PVRTC_RGBA4 = TextureFormat.PVRTC_RGBA4,
+            //ETC_RGB4 = TextureFormat.ETC_RGB4,
+            //EAC_R = TextureFormat.EAC_R,
+            //EAC_R_SIGNED = TextureFormat.EAC_R_SIGNED,
+            //EAC_RG = TextureFormat.EAC_RG,
+            //EAC_RG_SIGNED = TextureFormat.EAC_RG_SIGNED,
+            //ETC2_RGB = TextureFormat.ETC2_RGB,
+            //ETC2_RGBA1 = TextureFormat.ETC2_RGBA1,
+            //ETC2_RGBA8 = TextureFormat.ETC2_RGBA8,
+            ASTC_4x4 = TextureFormat.ASTC_4x4,
+
+            //ASTC_RGB_4x4 = TextureFormat.ASTC_RGB_4x4,
+            ASTC_5x5 = TextureFormat.ASTC_5x5,
+
+            //ASTC_RGB_5x5 = TextureFormat.ASTC_RGB_5x5,
+            ASTC_6x6 = TextureFormat.ASTC_6x6,
+
+            //ASTC_RGB_6x6 = TextureFormat.ASTC_RGB_6x6,
+            ASTC_8x8 = TextureFormat.ASTC_8x8,
+
+            //ASTC_RGB_8x8 = TextureFormat.ASTC_RGB_8x8,
+            ASTC_10x10 = TextureFormat.ASTC_10x10,
+
+            //ASTC_RGB_10x10 = TextureFormat.ASTC_RGB_10x10,
+            ASTC_12x12 = TextureFormat.ASTC_12x12,
+
+            //ASTC_RGB_12x12 = TextureFormat.ASTC_RGB_12x12,
+            //ASTC_RGBA_4x4 = TextureFormat.ASTC_RGBA_4x4,
+            //ASTC_RGBA_5x5 = TextureFormat.ASTC_RGBA_5x5,
+            //ASTC_RGBA_6x6 = TextureFormat.ASTC_RGBA_6x6,
+            //ASTC_RGBA_8x8 = TextureFormat.ASTC_RGBA_8x8,
+            //ASTC_RGBA_10x10 = TextureFormat.ASTC_RGBA_10x10,
+            //ASTC_RGBA_12x12 = TextureFormat.ASTC_RGBA_12x12,
+            RG16 = TextureFormat.RG16,
+            R8 = TextureFormat.R8,
+            //ETC_RGB4Crunched = TextureFormat.ETC_RGB4Crunched,
+            //ETC2_RGBA8Crunched = TextureFormat.ETC2_RGBA8Crunched,
+            //ASTC_HDR_4x4 = TextureFormat.ASTC_HDR_4x4,
+            //ASTC_HDR_5x5 = TextureFormat.ASTC_HDR_5x5,
+            //ASTC_HDR_6x6 = TextureFormat.ASTC_HDR_6x6,
+            //ASTC_HDR_8x8 = TextureFormat.ASTC_HDR_8x8,
+            //ASTC_HDR_10x10 = TextureFormat.ASTC_HDR_10x10,
+            //ASTC_HDR_12x12 = TextureFormat.ASTC_HDR_12x12,
+            //RG32 = TextureFormat.RG32,
+            //RGB48 = TextureFormat.RGB48,
+            //RGBA64 = TextureFormat.RGBA64,
+            // ReSharper restore InconsistentNaming
+        }
+    }
+}

--- a/Runtime/MergeMaterial.cs.meta
+++ b/Runtime/MergeMaterial.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9c47a2477e3743d48a58cab026e1416d
+timeCreated: 1756566882


### PR DESCRIPTION
This PR adds new version of MaterialToonLit: Merge Material.
This new component:

- Persists materials to save by Material reference instead of material index.
- Supports many shaders with information provided by ShaderInformation.

Closes #68 improve UI of Merge ToonLit
Closes #273 Merge MaterialをlilToonに対応させて欲しい
Closes #363 merge toonlit/materialのマテリアル指定がMergeSkinnedMeshの変更にすごく弱い
Closes #1455 More ShaderSupport for MergeToonLit / Merge Material

TODOs:
- [x] Component Definition
- [ ] Implement the component
  - [ ] Consider how do we handle non-uv0 textures.
- [ ] Warnings on the Inspector
- [ ] Feature to migrate MergeToonLit to MergeMaterial
- [ ] Reimplement MergeToonLit with new MergeMaterial implementation