### PR TITLE
fix: Emission Map of ToonStandard shader will be broken by optimize texture

### DIFF
--- a/Editor/APIInternal/ShaderInformation.VRCSDK.cs
+++ b/Editor/APIInternal/ShaderInformation.VRCSDK.cs
@@ -128,7 +128,7 @@ class VRCSDKToonStandardShaderInformation : ShaderInformation
             Register("_MatcapMask", UsingUVChannels.UV0);
         }
 
-        if (matInfo.IsShaderKeywordEnabled("USE_EMISSION_MAP") != false)
+        //if (matInfo.IsShaderKeywordEnabled("USE_EMISSION_MAP") != false) // Emission Map is always enabled since it's cheap
         {
             var uv = matInfo.GetFloat("_EmissionUV") switch
             {


### PR DESCRIPTION

Comment out the check for USE_EMISSION_MAP keyword as it is always enabled.