### PR TITLE
docs: add developers section onto top page

### DIFF
--- a/.docs/assets/_custom.scss
+++ b/.docs/assets/_custom.scss
@@ -190,3 +190,100 @@ code {
     opacity: 1;
   }
 }
+
+.main-dev-card {
+  display: flex;
+  border: 1px solid var(--custom-color-pale);
+  padding: 10px;
+  gap: 15px;
+  align-items: center;
+  margin-bottom: 1em;
+}
+
+.main-dev-icon-wrapper {
+  flex-shrink: 0.7;
+  --color-visited-link: transparent;
+  border-radius: 50%;
+}
+
+.main-dev-icon {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  aspect-ratio: 1;
+  flex-shrink: 1;
+  display: block;
+}
+
+.main-dev-name {
+  color: var(--custom-color-font) !important;
+  text-decoration: none !important;
+}
+
+.main-dev-name:hover {
+  text-decoration: underline !important;
+}
+
+.main-dev-info {
+  flex-basis: 450px;
+  flex-grow: 1;
+}
+
+.main-dev-card h3,p {
+  margin: 0;
+  margin-bottom: 0.2em;
+}
+
+.main-dev-card p {
+  font-size: 0.8em;
+  line-height: 1.5em;
+}
+
+.contributors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+  list-style: none;
+}
+
+.contributor {
+  position: relative;
+  display: inline-block;
+  text-decoration: none;
+}
+
+.contributor-icon {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.contributor-icon:hover {
+  transform: scale(1.1);
+}
+
+.contributor-tooltip {
+  visibility: hidden;
+  width: max-content;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  border-radius: 4px;
+  padding: 4px 8px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.3s;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.contributor:hover .contributor-tooltip {
+  visibility: visible;
+  opacity: 1;
+}

--- a/.docs/content/_index.ja.md
+++ b/.docs/content/_index.ja.md
@@ -80,6 +80,26 @@ vpm add repo https://vpm.anatawa12.com/vpm.json
 cd /path/to/your-unity-project
 vpm add package com.anatawa12.avatar-optimizer
 ```
+## 開発者 {#developers}
+
+本プロジェクトは、主に2名のコア開発者によって開発されています。
+
+{{< main-dev username="anatawa12" >}}
+プロジェクトの発起人であり、メインメンテナーです。\
+新機能の実装やバグ修正、ドキュメントの草稿作成などを主に担当しています。
+{{< /main-dev >}}
+
+{{< main-dev username="Sayamame-beans" >}}
+主にドキュメント編集を担当しています。\
+機能方針の検討やユーザーフィードバックの収集、プロジェクトの広報にも携わっています。
+{{< /main-dev >}}
+
+また、本プロジェクトの改善には、多くのコントリビューターの皆様にもご協力いただいています。
+以下は、その一部の方々です。
+
+皆様のご協力に心より感謝いたします。
+
+{{< contributors >}}
 
 [ALCOM]: https://vrc-get.anatawa12.com/alcom/
 [VPAI]: https://github.com/anatawa12/VPMPackageAutoInstaller

--- a/.docs/content/_index.md
+++ b/.docs/content/_index.md
@@ -86,6 +86,27 @@ cd /path/to/your-unity-project
 vpm add package com.anatawa12.avatar-optimizer
 ```
 
+## Developers {#developers}
+
+This project is mainly developed by two core developers:
+
+{{< main-dev username="anatawa12" >}}
+The initiator of the project and the main maintainer.\
+Primarily responsible for implementing new features, fixing bugs, and writing draft documentation.
+{{< /main-dev >}}
+
+{{< main-dev username="Sayamame-beans" >}}
+The main documentation editor.\
+They also contribute to feature planning, collecting user feedback, and promoting the project.
+{{< /main-dev >}}
+
+In addition, many contributors have helped improve this project.
+Here are some of them.
+
+Thank you all for your contributions!
+
+{{< contributors >}}
+
 [ALCOM]: https://vrc-get.anatawa12.com/alcom/
 [VPAI]: https://github.com/anatawa12/VPMPackageAutoInstaller
 [vpm]: https://vcc.docs.vrchat.com/vpm/

--- a/.docs/layouts/shortcodes/contributors.html
+++ b/.docs/layouts/shortcodes/contributors.html
@@ -1,0 +1,36 @@
+{{ $url := "https://api.github.com/repos/anatawa12/AvatarOptimizer/contributors" }}
+{{ $opts := dict
+    "method" "get"
+    "headers" (dict  "Content-Type" "application/json")
+}}
+{{ $resource := resources.GetRemote $url $opts }}
+{{ $known := dict
+    "22656849" "anatawa12"
+    "61457993" "Sayamame-beans"
+}}
+{{ with try (resources.GetRemote $url $opts) }}
+  {{ with .Err }}
+    {{ errorf "%s" . }}
+  {{ else with .Value }}
+    {{ $contributors := . | transform.Unmarshal }}
+      <ul class="contributors">
+        {{ range $contributor := $contributors }}
+        {{ if not (isset $known (string $contributor.id)) }}
+        <li>
+          <a
+                  class="contributor-icon contributor"
+                  aria-describedby="contributor-tooltip-{{ string $contributor.id }}"
+                  href="{{ $contributor.html_url }}"
+                  target="_blank"
+          >
+              <span class="contributor-tooltip" role="tooltip" id="contributor-tooltip-{{ string $contributor.id }}">{{ .login }}</span>
+              <img class="contributor-icon" src="{{ $contributor.avatar_url }}" alt="{{ $contributor.login }}" />
+          </a>
+        </li>
+        {{ end }}
+        {{ end }}
+      </ul>
+  {{ else }}
+    {{ errorf "Unable to get remote resource %q" $url }}
+  {{ end }}
+{{ end }}

--- a/.docs/layouts/shortcodes/main-dev.html
+++ b/.docs/layouts/shortcodes/main-dev.html
@@ -1,0 +1,12 @@
+{{ $id := .Get "username" }}
+<div class="main-dev-card">
+    <a class="main-dev-icon-wrapper" href="https://github.com/{{ $id }}" target="_blank">
+        <img class="main-dev-icon" src="https://avatars.githubusercontent.com/{{ $id }}?v=4" alt="anatawa12" />
+    </a>
+    <div class="main-dev-info">
+        <h3><a class="main-dev-name" href="https://github.com/{{ $id }}" target="_blank">{{ $id }}</a></h3>
+        <p>
+            {{ .Inner | .Page.RenderString }}
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
Add developers section to top page, similar to ALCOM top page, just for fun.

(additional info on comment)

<!--

Someone told us that there have been instances of individuals falsely claiming to be developers, so we have decided to explicitly identify core developers.

-->