### PR TITLE
VRCSDK 3.10.3 support

### DIFF
--- a/API-Editor/ComponentInformation.cs
+++ b/API-Editor/ComponentInformation.cs
@@ -394,6 +394,7 @@ namespace Anatawa12.AvatarOptimizer.API
 
         // requests AAO to preserve the properties. This is internally used to preserve some blendshapes.
         internal abstract void PreserveProperties(Component component, IEnumerable<string> properties);
+        internal abstract void ModifyProperties(GameObject go, IEnumerable<string> properties);
     }
 
     /// <summary>

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog].
 ## [Unreleased]
 ### Added
 - Added support for `VRCRaycast` component added in VRCSDK 3.10.3 `#1706`
+  - This also add support for `RaycastCount` performance category `#1706`
+- Added support for ToonStandard `ColorMask` property `#1706`
 
 ### Changed
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 ### Added
+- Added support for `VRCRaycast` component added in VRCSDK 3.10.3 `#1706`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog].
 ## [Unreleased]
 ### Added
 - Added support for `VRCRaycast` component added in VRCSDK 3.10.3 `#1706`
+  - This also add support for `RaycastCount` performance category `#1706`
+- Added support for ToonStandard `ColorMask` property `#1706`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 ### Added
+- Added support for `VRCRaycast` component added in VRCSDK 3.10.3 `#1706`
 
 ### Changed
 

--- a/Editor/APIInternal/ComponentInfos.VRCSDK.cs
+++ b/Editor/APIInternal/ComponentInfos.VRCSDK.cs
@@ -652,40 +652,37 @@ namespace Anatawa12.AvatarOptimizer.APIInternal.VRCSDK
     {
         protected override void CollectDependency(VRCRaycast component, ComponentDependencyCollector collector)
         {
-            var transform = GetResultTransform(component);
-            if (transform == null) return; // Raycast do nothing if target is null
-            collector.AddDependency(transform, component);
+            var transform = component.ResultTransform;
+            if (transform != null) // Raycast do nothing if target is null
+            {
+                collector.AddDependency(transform, component);
+                collector.MarkBehaviour();
+            }
+
+            // if the component drives parameter that is used, 
+            // we need to keep the raycast
+            if (new[]
+                {
+                    component.Parameter + VRCRaycast.PARAM_DISTANCE,
+                    component.Parameter + VRCRaycast.PARAM_HIT,
+                    component.Parameter + VRCRaycast.PARAM_RATIO,
+                }.Any(collector.IsParameterUsed))
+            {
+                collector.MarkEntrypoint();
+            }
         }
 
         protected override void CollectMutations(VRCRaycast component, ComponentMutationsCollector collector)
         {
-            var transform = GetResultTransform(component);
-            if (transform == null) return; // Raycast do nothing if target is null
-            collector.TransformPosition(transform);
-            if (GetApplyRotation(component))
-                collector.TransformRotation(transform);
-            if (DisableOnMiss(component))
-                collector.ModifyProperties(transform.gameObject, new [] { "m_IsActive" });
-        }
-
-        // fields are private for now
-        // See canny: https://feedback.vrchat.com/open-beta/p/sdk-3103-beta1-please-expose-vrcraycast-configuration-fields-as-public
-        private static Transform? GetResultTransform(VRCRaycast component)
-        {
-            using var serialized = new UnityEditor.SerializedObject(component);
-            return serialized.FindProperty("resultTransform")?.objectReferenceValue as Transform;
-        }
-
-        private static bool GetApplyRotation(VRCRaycast component)
-        {
-            using var serialized = new UnityEditor.SerializedObject(component);
-            return serialized.FindProperty("applyRotation")?.boolValue ?? false;
-        }
-
-        private static bool DisableOnMiss(VRCRaycast component)
-        {
-            using var serialized = new UnityEditor.SerializedObject(component);
-            return serialized.FindProperty("disableOnMiss")?.boolValue ?? false;
+            var transform = component.ResultTransform;
+            if (transform != null) // Raycast do nothing if target is null
+            {
+                collector.TransformPosition(transform);
+                if (component.ApplyRotation)
+                    collector.TransformRotation(transform);
+                if (component.DisableOnMiss)
+                    collector.ModifyProperties(transform.gameObject, new[] { "m_IsActive" });
+            }
         }
     }
 #endif

--- a/Editor/APIInternal/ComponentInfos.VRCSDK.cs
+++ b/Editor/APIInternal/ComponentInfos.VRCSDK.cs
@@ -655,6 +655,7 @@ namespace Anatawa12.AvatarOptimizer.APIInternal.VRCSDK
             var transform = component.ResultTransform;
             if (transform != null) // Raycast do nothing if target is null
             {
+                collector.AddDependency(transform);
                 collector.AddDependency(transform, component);
                 collector.MarkBehaviour();
             }
@@ -681,7 +682,7 @@ namespace Anatawa12.AvatarOptimizer.APIInternal.VRCSDK
                 if (component.ApplyRotation)
                     collector.TransformRotation(transform);
                 if (component.DisableOnMiss)
-                    collector.ModifyProperties(transform.gameObject, new[] { "m_IsActive" });
+                    collector.ModifyProperties(transform.gameObject, new[] { Props.IsActive });
             }
         }
     }

--- a/Editor/APIInternal/ComponentInfos.VRCSDK.cs
+++ b/Editor/APIInternal/ComponentInfos.VRCSDK.cs
@@ -645,5 +645,49 @@ namespace Anatawa12.AvatarOptimizer.APIInternal.VRCSDK
         {
         }
     }
+
+#if AAO_VRCSDK3_AVATARS_VRC_RAYCAST
+    [ComponentInformation(typeof(VRCRaycast))]
+    internal class VRCRaycastInformation : ComponentInformation<VRCRaycast>
+    {
+        protected override void CollectDependency(VRCRaycast component, ComponentDependencyCollector collector)
+        {
+            var transform = GetResultTransform(component);
+            if (transform == null) return; // Raycast do nothing if target is null
+            collector.AddDependency(transform, component);
+        }
+
+        protected override void CollectMutations(VRCRaycast component, ComponentMutationsCollector collector)
+        {
+            var transform = GetResultTransform(component);
+            if (transform == null) return; // Raycast do nothing if target is null
+            collector.TransformPosition(transform);
+            if (GetApplyRotation(component))
+                collector.TransformRotation(transform);
+            if (DisableOnMiss(component))
+                collector.ModifyProperties(transform.gameObject, new [] { "m_IsActive" });
+        }
+
+        // fields are private for now
+        // See canny: https://feedback.vrchat.com/open-beta/p/sdk-3103-beta1-please-expose-vrcraycast-configuration-fields-as-public
+        private static Transform? GetResultTransform(VRCRaycast component)
+        {
+            using var serialized = new UnityEditor.SerializedObject(component);
+            return serialized.FindProperty("resultTransform")?.objectReferenceValue as Transform;
+        }
+
+        private static bool GetApplyRotation(VRCRaycast component)
+        {
+            using var serialized = new UnityEditor.SerializedObject(component);
+            return serialized.FindProperty("applyRotation")?.boolValue ?? false;
+        }
+
+        private static bool DisableOnMiss(VRCRaycast component)
+        {
+            using var serialized = new UnityEditor.SerializedObject(component);
+            return serialized.FindProperty("disableOnMiss")?.boolValue ?? false;
+        }
+    }
+#endif
 }
 #endif

--- a/Editor/APIInternal/ShaderInformation.VRCSDK.cs
+++ b/Editor/APIInternal/ShaderInformation.VRCSDK.cs
@@ -167,7 +167,7 @@ class VRCSDKToonStandardShaderInformation : ShaderInformation
             Register("_HueShiftMask", UsingUVChannels.UV0);
         }
 
-        // New added in 3.10.3
+        // Added in 3.10.3
         if (matInfo.IsShaderKeywordEnabled("USE_COLOR_MASK") != false)
         {
             Register("_ColorMask", UsingUVChannels.UV0);

--- a/Editor/APIInternal/ShaderInformation.VRCSDK.cs
+++ b/Editor/APIInternal/ShaderInformation.VRCSDK.cs
@@ -167,6 +167,12 @@ class VRCSDKToonStandardShaderInformation : ShaderInformation
             Register("_HueShiftMask", UsingUVChannels.UV0);
         }
 
+        // New added in 3.10.3
+        if (matInfo.IsShaderKeywordEnabled("USE_COLOR_MASK") != false)
+        {
+            Register("_ColorMask", UsingUVChannels.UV0);
+        }
+
         if (withOutline)
         {
             // note: this does not require the mipmap

--- a/Editor/AnimatorParserV2/AnimatorParser.cs
+++ b/Editor/AnimatorParserV2/AnimatorParser.cs
@@ -143,6 +143,14 @@ namespace Anatawa12.AvatarOptimizer.AnimatorParsersV2
                 }
             }
 
+            internal override void ModifyProperties(GameObject go, IEnumerable<string> properties)
+            {
+                foreach (var prop in properties)
+                {
+                    _modifications.Add(go, prop, new VariableComponentPropModNode(Modifier!), ApplyState.Always);
+                }
+            }
+
             internal override void PreserveProperties(Component component, IEnumerable<string> properties)
             {
                 foreach (var prop in properties)

--- a/Editor/AnimatorParserV2/NodeContainer.cs
+++ b/Editor/AnimatorParserV2/NodeContainer.cs
@@ -59,7 +59,7 @@ namespace Anatawa12.AvatarOptimizer.AnimatorParsersV2
             }
         }
 
-        public void Add(Component component, string prop, ComponentPropModNodeBase<FloatValueInfo> node, ApplyState applyState)
+        public void Add(ComponentOrGameObject component, string prop, ComponentPropModNodeBase<FloatValueInfo> node, ApplyState applyState)
         {
             var key = (component, prop);
             if (!FloatNodes.TryGetValue(key, out var root))
@@ -67,7 +67,7 @@ namespace Anatawa12.AvatarOptimizer.AnimatorParsersV2
             root.Add(node, applyState);
         }
 
-        public void Add(Component component, string prop, ComponentPropModNodeBase<ObjectValueInfo> node, ApplyState applyState)
+        public void Add(ComponentOrGameObject component, string prop, ComponentPropModNodeBase<ObjectValueInfo> node, ApplyState applyState)
         {
             var key = (component, prop);
             if (!_objectNodes.TryGetValue(key, out var root))

--- a/Editor/Processors/OptimizationMetrics.cs
+++ b/Editor/Processors/OptimizationMetrics.cs
@@ -255,6 +255,9 @@ internal static class OptimizationMetricsImpl
             Add(AvatarPerformanceCategory.TextureMegabytes, s => ToStringMegabytes(s.textureMegabytes));
             Add(AvatarPerformanceCategory.ConstraintsCount, s => ToStringCount(s.constraintsCount));
             Add(AvatarPerformanceCategory.ConstraintDepth, s => ToStringCount(s.constraintDepth));
+#if AAO_VRCSDK3_AVATARS_VRC_RAYCAST
+            Add(AvatarPerformanceCategory.RaycastCount, s => ToStringCount(s.raycastCount));
+#endif
             return dict;
         }
     }

--- a/Editor/com.anatawa12.avatar-optimizer.editor.asmdef
+++ b/Editor/com.anatawa12.avatar-optimizer.editor.asmdef
@@ -65,6 +65,11 @@
             "define": "AAO_VRCSDK3_AVATARS_IGNORE_OTHER_PHYSBONE"
         },
         {
+            "name": "com.vrchat.avatars",
+            "expression": "3.10.3-beta.1",
+            "define": "AAO_VRCSDK3_AVATARS_VRC_RAYCAST"
+        },
+        {
             "name": "com.vrmc.univrm",
             "expression": "",
             "define": "AAO_VRM0"

--- a/Editor/com.anatawa12.avatar-optimizer.editor.asmdef
+++ b/Editor/com.anatawa12.avatar-optimizer.editor.asmdef
@@ -66,7 +66,7 @@
         },
         {
             "name": "com.vrchat.avatars",
-            "expression": "3.10.3-beta.1",
+            "expression": "3.10.3-beta.2",
             "define": "AAO_VRCSDK3_AVATARS_VRC_RAYCAST"
         },
         {


### PR DESCRIPTION
This PR adds support for new features added in VRCSDK 3.10.3-beta.1.

This includes:
- ColorMask feature in ToonStandard shader suite
- VRCRaycast component support
- Raycast Count Performance Category Support in Optimization Metrics

For component support, VRCSDK sadly declares their fields as private so I have written request for exposing them [1].
We'll keep this PR draft a while to see VRChat team response for the canny.

[1]: https://feedback.vrchat.com/open-beta/p/sdk-3103-beta1-please-expose-vrcraycast-configuration-fields-as-public