### PR TITLE
ci: hey @github, "safer default" is not letter of indulgence for breaking changes

### DIFF
--- a/.github/workflows/gameci.yml
+++ b/.github/workflows/gameci.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           path: Packages/com.anatawa12.avatar-optimizer
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - uses: anatawa12/sh-actions/setup-vrc-get@master
       - run: vrc-get install -y com.vrchat.avatars
       - uses: anatawa12/sh-actions/resolve-vpm-packages@master


### PR DESCRIPTION
this does not change anything useful, except for breaking changes with safer default as a letter of indulgence.

hey @github, please provide "safe way" to let external pull_request workflows to read 'some' secret variables and put checks to github pull request without requireing checks: write permission.
those are the only reason why we still need to use pull_request_target.