### PR TITLE
ci: safer gameci

### DIFF
--- a/.github/workflows/gameci-reports.yml
+++ b/.github/workflows/gameci-reports.yml
@@ -1,0 +1,18 @@
+name: GameCI Reports
+
+on:
+  workflow_run:
+    workflows: ['GameCI']
+    types:
+      - completed
+
+jobs:
+  build-and-test:
+    - uses: dorny/test-reporter@v3
+      if: always()
+      with:
+        reporter: dotnet-nunit
+        artifact: /Test results (.*)/
+        name: 'Test report $1'
+        fail-on-empty: false
+        path: '*.xml'

--- a/.github/workflows/gameci-reports.yml
+++ b/.github/workflows/gameci-reports.yml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   build-and-test:
-    - uses: dorny/test-reporter@v3
-      if: always()
-      with:
-        reporter: dotnet-nunit
-        artifact: /Test results (.*)/
-        name: 'Test report $1'
-        fail-on-empty: false
-        path: '*.xml'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          reporter: dotnet-nunit
+          artifact: /Test results (.*)/
+          name: 'Test report $1'
+          fail-on-empty: false
+          path: '*.xml'

--- a/.github/workflows/gameci.yml
+++ b/.github/workflows/gameci.yml
@@ -1,10 +1,14 @@
 name: GameCI
+# note: name is referenced by other workflow
 
 on:
   push:
     branches: [ master, master-* ]
   pull_request_target: {}
   workflow_dispatch: {}
+
+permissions:
+  checks: read
 
 jobs:
   build-and-test:
@@ -17,16 +21,16 @@ jobs:
             projectRef: d2e10f445881af7cc806abd2fc99a0651942dbb8 # project-for-test-2022
         unity:
           - 2022
-    permissions:
-      checks: write
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.projectRef }}
+          persist-credentials: false
       - uses: actions/checkout@v4
         with:
           path: Packages/com.anatawa12.avatar-optimizer
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
           allow-unsafe-pr-checkout: true
       - uses: anatawa12/sh-actions/setup-vrc-get@master
       - run: vrc-get install -y com.vrchat.avatars
@@ -55,14 +59,6 @@ jobs:
       - name: "Show files at root folder to find crash log"
         if: always()
         run: ls -la
-
-      - uses: dorny/test-reporter@v2
-        if: always()
-        with:
-          reporter: dotnet-nunit
-          name: EditMode Tests
-          fail-on-empty: false
-          path: ${{ steps.gameci.outputs.artifactsPath }}/editmode-results.xml
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/gameci.yml
+++ b/.github/workflows/gameci.yml
@@ -8,8 +8,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  checks: read
-
+  contents: read
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -41,7 +40,7 @@ jobs:
             https://vpm.nadena.dev/vpm-prerelease.json
 
       - uses: actions/cache@v4
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           path: Library
           key: Library-${{ matrix.unity }}

--- a/.github/workflows/gameci.yml
+++ b/.github/workflows/gameci.yml
@@ -41,6 +41,7 @@ jobs:
             https://vpm.nadena.dev/vpm-prerelease.json
 
       - uses: actions/cache@v4
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           path: Library
           key: Library-${{ matrix.unity }}


### PR DESCRIPTION
although we still need to run code in `pull_request_target`, we can minimize risks by removing secrets from storage (persist-secrets = false) and removing `checks: write` permission