### PR TITLE
fix: false positive 'differently animated' errors/warnings by normalize animation curve early

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Missing localization for few messages `#1767`
+- False positive "Differently animated BlendShape is detected" error in Merge Skinned Mesh with MA BlendShape Sync `#1778`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Missing localization for few messages `#1767`
+- False positive "Differently animated BlendShape is detected" error in Merge Skinned Mesh with MA BlendShape Sync `#1778`
 
 ### Security
 

--- a/Editor/AnimatorParserV2/PropModNode.cs
+++ b/Editor/AnimatorParserV2/PropModNode.cs
@@ -452,6 +452,14 @@ namespace Anatawa12.AvatarOptimizer.AnimatorParsersV2
             Clip = clip;
             var curve = AnimationUtility.GetEditorCurve(clip, binding);
             Curve = curve ?? throw new ArgumentException("The binding is not valid for the clip", nameof(binding));
+            // Normalize animation curve to prevent false positive 'different animation' detection.
+            // The free tangent broken keypoints can represent all other modes as far as I know.
+            for (var i = 0; i < curve.length; i++)
+            {
+                AnimationUtility.SetKeyBroken(curve, i, true);
+                AnimationUtility.SetKeyLeftTangentMode(curve, i, AnimationUtility.TangentMode.Free);
+                AnimationUtility.SetKeyRightTangentMode(curve, i, AnimationUtility.TangentMode.Free);
+            }
             _constantInfo = new Lazy<FloatValueInfo>(() => ParseProperty(curve, additiveReferenceClip, binding, additiveReferenceFrame), isThreadSafe: false);
         }
 

--- a/Test~/E2E/E2ETesting.cs
+++ b/Test~/E2E/E2ETesting.cs
@@ -1146,5 +1146,58 @@ namespace Anatawa12.AvatarOptimizer.Test.E2E
         }
 
         #endregion
+
+        [Test]
+        public void Issue1777MergeSmrMergeSameNameSameCurveWithDifferentKeySettings()
+        {
+            // mesh A and B has blendShape named "BlendShape" and merged to single mesh with manually configured MergeSMR
+            // Animation targeting A.BlendShape and B.BlendShape have curves with same behavior, but different keyframe options
+            var avatar = TestUtils.NewAvatar();
+            var meshA = TestUtils.NewCubeMesh();
+            meshA.AddBlendShapeFrame("BlendShape", 100f, TestUtils.NewCubeBlendShapeFrame((0, Vector3.up)), null, null);
+            var meshB = TestUtils.NewCubeMesh();
+            meshB.AddBlendShapeFrame("BlendShape", 100f, TestUtils.NewCubeBlendShapeFrame((0, Vector3.up)), null, null);
+            var goA = Utils.NewGameObject("MeshA", avatar.transform);
+            var goB = Utils.NewGameObject("MeshB", avatar.transform);
+            var smrA = goA.AddComponent<SkinnedMeshRenderer>();
+            var smrB = goB.AddComponent<SkinnedMeshRenderer>();
+            smrA.sharedMesh = meshA;
+            smrB.sharedMesh = meshB;
+            var mergeSMRGO = Utils.NewGameObject("MergeSMR", avatar.transform);
+            var mergeSMRRenderer = mergeSMRGO.AddComponent<SkinnedMeshRenderer>();
+            var mergeSMR = mergeSMRGO.AddComponent<MergeSkinnedMesh>();
+            mergeSMR.blendShapeMode = MergeSkinnedMesh.BlendShapeMode.MergeSameName;
+            mergeSMR.renderersSet.SetValueNonPrefab(new[] { smrA, smrB });
+            mergeSMRRenderer.probeAnchor = mergeSMR.transform;
+            mergeSMRRenderer.rootBone = mergeSMR.transform;
+
+            var curveA = new AnimationCurve(new Keyframe(0, 0), new Keyframe(1, 100));
+            var curveB = new AnimationCurve(curveA.keys)
+                { preWrapMode = curveA.preWrapMode, postWrapMode = curveA.postWrapMode };
+
+            // curveB has broken, free tangents, which is the case with Modular Avatar 1.18.0..=1.18.1
+            for (var i = 0; i < curveB.length; i++)
+            {
+                AnimationUtility.SetKeyBroken(curveB, i, true);
+                AnimationUtility.SetKeyLeftTangentMode(curveB, i, AnimationUtility.TangentMode.Free);
+                AnimationUtility.SetKeyRightTangentMode(curveB, i, AnimationUtility.TangentMode.Free);
+            }
+
+            TestUtils.SetFxLayer(avatar, new AnimatorControllerBuilder("")
+                .AddLayer("Base Layer", sm =>
+                {
+                    sm.NewClipState("AnimateBlendShapes", clip => clip
+                        .AddPropertyBinding("MeshA", typeof(SkinnedMeshRenderer), "blendShape.BlendShape", curveA)
+                        .AddPropertyBinding("MeshB", typeof(SkinnedMeshRenderer), "blendShape.BlendShape", curveB));
+                })
+                .Build());
+
+            LogTestUtility.Test(_ =>
+            {
+                AvatarProcessor.ProcessAvatar(avatar);
+            });
+
+            // if no error is reported, test is passed
+        }
     }
 }


### PR DESCRIPTION
Fixes #1777

I changed modular avatar to normalize AnimationCurve to broken keypoints and free tangent even if original curve is identity curve by mistake while fixing 'remap curve' feature problems in https://github.com/bdunderscore/modular-avatar/pull/2034.

While I'm working on modular-avatar to restore previous behavior in https://github.com/bdunderscore/modular-avatar/pull/2097, I also fix this issue on our side.

This normalizes animation curves in same way as modular-avatar does. Since both tools have exactly same method, both curves become exactly same curve and AAO treats these curves as same curve.